### PR TITLE
Leaks

### DIFF
--- a/meter/subscription_counter.h
+++ b/meter/subscription_counter.h
@@ -66,7 +66,7 @@ class SubscriptionCounterNumber : public Meter, public CounterNumber<T> {
     auto new_size = poller_frequency_.size();
     if (new_size > current_size_) {
       for (auto i = current_size_; i < new_size; ++i) {
-        step_numbers_[i] = new StepNumber<T>(0, poller_frequency_[i], clock_);
+        step_numbers_[i] = std::make_unique<StepNumber<T>>(0, poller_frequency_[i], clock_);
       }
     }
     current_size_ = new_size;
@@ -75,7 +75,7 @@ class SubscriptionCounterNumber : public Meter, public CounterNumber<T> {
  private:
   std::size_t current_size_;  // MUST be < MAX_POLLER_FREQ
 
-  using StepNumbers = std::array<StepNumber<T>*, MAX_POLLER_FREQ>;
+  using StepNumbers = std::array<std::unique_ptr<StepNumber<T>>, MAX_POLLER_FREQ>;
   mutable StepNumbers step_numbers_;
   std::atomic<T> value_;  // to keep the total count
   const Pollers& poller_frequency_;

--- a/util/http.cc
+++ b/util/http.cc
@@ -171,6 +171,7 @@ static int do_post(const char* url, int connect_timeout, int read_timeout,
   if (!error) {
     logger->info("Was able to POST to {} - status code: {}", url, http_code);
   }
+  curl_slist_free_all(headers);
   return static_cast<int>(http_code);
 }
 
@@ -196,6 +197,7 @@ int http::post(const std::string& url, int connect_timeout, int read_timeout,
         "Failed to compress payload: {}, while posting to {} - uncompressed "
         "size: {}",
         compress_res, url, size);
+    curl_slist_free_all(headers);
     return 400;
   }
 


### PR DESCRIPTION
Fix memory leaks:

* We were not releasing the list of headers in HTTP requests
* We were not freeing the `StepNumber`s created by counters and max gauges.