### PR TITLE
Intern strings used by Tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,20 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     link_directories(/usr/lib/x86_64-linux-gnu)
 endif()
 
-file(GLOB LIB_SOURCE_FILES 
-  atlas_client.cc atlas_client.h types.h
-  meter/*.h meter/*.cc 
-  util/*.h util/*.cc
-  interpreter/*.h interpreter/*.cc)
+set(LIB_SOURCE_FILES
+    util/intern.cc util/xxhash.c util/config.cc util/config_manager.cc util/environment.cc
+    util/gzip.cc util/http.cc util/logger.cc util/strings.cc atlas_client.cc 
+    meter/bucket_counter.cc meter/bucket_distribution_summary.cc meter/bucket_functions.cc
+    meter/bucket_timer.cc meter/clock.cc meter/id.cc meter/interval_counter.cc meter/monotonic_counter.cc
+    meter/percentile_buckets.cc meter/percentile_dist_summary.cc meter/percentile_timer.cc meter/statistic.cc
+    meter/subscription_gauge.cc meter/subscription_long_task_timer.cc meter/subscription_manager.cc
+    meter/subscription_registry.cc meter/subscription_timer.cc meter/validation.cc
+    interpreter/aggregation.cc interpreter/all.cc interpreter/context.cc interpreter/expression.cc
+    interpreter/group_by.cc interpreter/interpreter.cc interpreter/keep_drop_tags.cc
+    interpreter/multiple_results.cc interpreter/query.cc interpreter/vocabulary.cc)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic -Werror -Wall -std=c99 -fpic -D_GNU_SOURCE")
+set(CMAKE_C_FLAGS_RELEASE "-O3 -march=native")
 
 add_library(atlasclient SHARED ${LIB_SOURCE_FILES})
 set_target_properties(atlasclient PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wno-missing-braces")
@@ -27,14 +36,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   configure_file(${CMAKE_SOURCE_DIR}/bundle/libcurl-linux.a libcurl.a COPYONLY)
   configure_file(${CMAKE_SOURCE_DIR}/bundle/libpcre-linux.a libpcre.a COPYONLY)
   add_library(atlasclientStatic STATIC ${LIB_SOURCE_FILES})
-  set_target_properties(atlasclientStatic PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wno-missing-braces")
   set_target_properties(atlasclientStatic PROPERTIES OUTPUT_NAME atlasclient)
   target_link_libraries(atlasclientStatic ${CMAKE_BINARY_DIR}/libpcre.a ${CMAKE_BINARY_DIR}/libcurl.a z)
 else()
   configure_file(${CMAKE_SOURCE_DIR}/bundle/libcurl-osx.a libcurl.a COPYONLY)
   configure_file(${CMAKE_SOURCE_DIR}/bundle/libpcre-osx.a libpcre.a COPYONLY)
 endif()
-target_link_libraries(atlasclient ${CMAKE_BINARY_DIR}/libpcre.a ${CMAKE_BINARY_DIR}/libcurl.a z)
+target_link_libraries(atlasclient ${CMAKE_BINARY_DIR}/libpcre.a ${CMAKE_BINARY_DIR}/libcurl.a z )
 
 set(APP_SOURCE_FILES main.cc)
 add_executable(native_client ${APP_SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     link_directories(/usr/lib/x86_64-linux-gnu)
 endif()
 
+# We need to initialize intern.cc first, since other files depend on it
+# for interning strings directly or indirectly using static Tags
 set(LIB_SOURCE_FILES
     util/intern.cc util/xxhash.c util/config.cc util/config_manager.cc util/environment.cc
     util/gzip.cc util/http.cc util/logger.cc util/strings.cc atlas_client.cc 

--- a/atlas_client.cc
+++ b/atlas_client.cc
@@ -77,7 +77,7 @@ class AtlasClient {
     std::transform(
         measurements.begin(), measurements.end(),
         std::back_inserter(tagsValuePairs), [](const Measurement& measurement) {
-          return TagsValuePair::from(measurement, atlas::meter::Tags());
+          return TagsValuePair::from(measurement, atlas::meter::kEmptyTags);
         });
 
     subscription_manager->PushMeasurements(atlas_registry.clock().WallTime(),

--- a/atlas_client.cc
+++ b/atlas_client.cc
@@ -77,7 +77,7 @@ class AtlasClient {
     std::transform(
         measurements.begin(), measurements.end(),
         std::back_inserter(tagsValuePairs), [](const Measurement& measurement) {
-          return TagsValuePair::from(measurement, atlas::meter::kEmptyTags);
+          return TagsValuePair::from(measurement, atlas::meter::Tags());
         });
 
     subscription_manager->PushMeasurements(atlas_registry.clock().WallTime(),

--- a/interpreter/expression.cc
+++ b/interpreter/expression.cc
@@ -8,7 +8,6 @@ namespace interpreter {
 using meter::Measurements;
 using util::Logger;
 using util::intern_str;
-using util::to_string;
 
 Literal::Literal(std::string str) noexcept : str_(std::move(str)) {}
 
@@ -94,7 +93,7 @@ std::ostream& operator<<(std::ostream& os, const TagsValuePair& tagsValuePair) {
     } else {
       first = false;
     }
-    os << to_string(tag.first) << "=" << to_string(tag.second);
+    os << tag.first.get() << "=" << tag.second.get();
   }
   os << ", value=" << tagsValuePair.value << "}";
   return os;

--- a/interpreter/expression.h
+++ b/interpreter/expression.h
@@ -8,6 +8,8 @@
 namespace atlas {
 namespace interpreter {
 
+using StringRefs = std::vector<util::StrRef>;
+
 enum class ExpressionType {
   Literal,
   List,
@@ -59,7 +61,7 @@ class List : public Expression {
 
   bool Contains(const std::string& key) const noexcept;
 
-  std::unique_ptr<Strings> ToStrings() const;
+  std::unique_ptr<StringRefs> ToStrings() const;
 
   size_t Size() const noexcept;
 

--- a/interpreter/group_by.h
+++ b/interpreter/group_by.h
@@ -24,7 +24,7 @@ class GroupBy : public MultipleResults {
   virtual std::ostream& Dump(std::ostream& os) const override;
 
  private:
-  std::unique_ptr<Strings> keys_;
+  std::unique_ptr<StringRefs> keys_;
   std::shared_ptr<ValueExpression> expr_;
 };
 

--- a/interpreter/keep_drop_tags.cc
+++ b/interpreter/keep_drop_tags.cc
@@ -12,7 +12,6 @@ namespace interpreter {
 using meter::Measurements;
 using util::StrRef;
 using util::intern_str;
-using util::to_string;
 
 const static auto kNameRef = intern_str("name");
 

--- a/interpreter/keep_drop_tags.cc
+++ b/interpreter/keep_drop_tags.cc
@@ -1,29 +1,36 @@
 #include "keep_drop_tags.h"
 #include "../meter/id.h"
 #include "../meter/measurement.h"
+#include "../util/dump.h"
 #include <algorithm>
 #include <unordered_set>
+#include <iostream>
 
 namespace atlas {
 namespace interpreter {
 
-using ::atlas::meter::Measurements;
+using meter::Measurements;
+using util::StrRef;
+using util::intern_str;
+using util::to_string;
 
-const static std::string name_str{"name"};
+const static auto kNameRef = intern_str("name");
+
 KeepOrDropTags::KeepOrDropTags(const List& keys,
                                std::shared_ptr<ValueExpression> expr, bool keep)
     : keys_(keys.ToStrings()), expr_(std::move(expr)), keep_(keep) {
   if (keep) {
     // make sure we keep name, it's required
-    if (std::find(keys_->begin(), keys_->end(), name_str) == keys_->end()) {
-      keys_->push_back(name_str);
+    if (std::find(keys_->begin(), keys_->end(), kNameRef) == keys_->end()) {
+      keys_->push_back(kNameRef);
     }
   }
 }
 
-static Strings drop_keys(const meter::Tags& tags, const Strings& keys) {
-  std::unordered_set<std::string> keys_set(keys.begin(), keys.end());
-  Strings res{name_str};
+using StringRefs = std::vector<StrRef>;
+static StringRefs drop_keys(const meter::Tags& tags, const StringRefs& keys) {
+  std::unordered_set<StrRef> keys_set(keys.begin(), keys.end());
+  StringRefs res{kNameRef};
 
   // add all tag keys that are not in the set of keys to be dropped
   for (const auto& tag : tags) {
@@ -36,7 +43,7 @@ static Strings drop_keys(const meter::Tags& tags, const Strings& keys) {
 
 TagsValuePairs KeepOrDropTags::Apply(const TagsValuePairs& valuePairs) {
   // group metrics by keys
-  std::map<meter::Tags, TagsValuePairs> grouped;
+  std::unordered_map<meter::Tags, TagsValuePairs> grouped;
   for (auto& valuePair : valuePairs) {
     auto should_keep = true;
     meter::Tags group_by_vals;
@@ -46,7 +53,7 @@ TagsValuePairs KeepOrDropTags::Apply(const TagsValuePairs& valuePairs) {
     for (auto& key : keys) {
       auto value = get_value(valuePair, key);
       if (value) {
-        group_by_vals[key] = value.get();
+        group_by_vals.add(key, intern_str(value.get()));
       } else {
         should_keep = false;
         break;

--- a/interpreter/keep_drop_tags.h
+++ b/interpreter/keep_drop_tags.h
@@ -22,7 +22,7 @@ class KeepOrDropTags : public MultipleResults {
   virtual std::ostream& Dump(std::ostream& os) const override;
 
  private:
-  std::unique_ptr<Strings> keys_;
+  std::unique_ptr<StringRefs> keys_;
   std::shared_ptr<ValueExpression> expr_;
   bool keep_;
 };

--- a/interpreter/multiple_results.cc
+++ b/interpreter/multiple_results.cc
@@ -5,15 +5,13 @@
 namespace atlas {
 namespace interpreter {
 
-using util::to_string;
-
 const OptionalString kNone{nullptr};
 
 OptionalString MultipleResults::get_value(const TagsValuePair& tagsValuePair,
                                           const util::StrRef k) {
   auto it = tagsValuePair.tags.find(k);
   if (it != tagsValuePair.tags.end()) {
-    return OptionalString{to_string((*it).second)};
+    return OptionalString{(*it).second.get()};
   }
 
   return kNone;
@@ -29,7 +27,7 @@ std::string MultipleResults::keys_str(StringRefs strings) {
     } else {
       first = false;
     }
-    os << to_string(s);
+    os << s.get();
   }
   return os.str();
 }

--- a/interpreter/multiple_results.cc
+++ b/interpreter/multiple_results.cc
@@ -1,22 +1,25 @@
 #include "multiple_results.h"
+#include "../meter/id.h"
 #include <sstream>
 
 namespace atlas {
 namespace interpreter {
 
+using util::to_string;
+
 const OptionalString kNone{nullptr};
 
 OptionalString MultipleResults::get_value(const TagsValuePair& tagsValuePair,
-                                          const std::string& k) {
+                                          const util::StrRef k) {
   auto it = tagsValuePair.tags.find(k);
   if (it != tagsValuePair.tags.end()) {
-    return OptionalString{(*it).second};
+    return OptionalString{to_string((*it).second)};
   }
 
   return kNone;
 }
 
-std::string MultipleResults::keys_str(std::vector<std::string> strings) {
+std::string MultipleResults::keys_str(StringRefs strings) {
   std::ostringstream os;
 
   auto first = true;
@@ -26,7 +29,7 @@ std::string MultipleResults::keys_str(std::vector<std::string> strings) {
     } else {
       first = false;
     }
-    os << s;
+    os << to_string(s);
   }
   return os.str();
 }

--- a/interpreter/multiple_results.h
+++ b/interpreter/multiple_results.h
@@ -13,8 +13,8 @@ class MultipleResults : public Expression {
 
  protected:
   static OptionalString get_value(const TagsValuePair& tagsValuePair,
-                                  const std::string& k);
-  static std::string keys_str(std::vector<std::string>);
+                                  util::StrRef k);
+  static std::string keys_str(StringRefs strings);
 };
 }
 }

--- a/interpreter/query.cc
+++ b/interpreter/query.cc
@@ -8,7 +8,6 @@ namespace interpreter {
 using util::Logger;
 using util::StrRef;
 using util::intern_str;
-using util::to_string;
 
 const OptionalString kNone{nullptr};
 
@@ -38,7 +37,7 @@ const OptionalString AbstractKeyQuery::getvalue(const meter::Tags& tags) const
   if (k == tags.end()) {
     return kNone;
   }
-  return OptionalString{to_string((*k).second)};
+  return OptionalString{k->second.get()};
 }
 
 const std::string& AbstractKeyQuery::Key() const noexcept { return key_; }

--- a/interpreter/query.h
+++ b/interpreter/query.h
@@ -41,6 +41,8 @@ class AbstractKeyQuery : public Query {
 
   const std::string& Key() const noexcept;
 
+  util::StrRef KeyRef() const noexcept;
+
  private:
   const std::string key_;
 
@@ -124,7 +126,7 @@ class RegexQuery : public AbstractKeyQuery {
 
 class InQuery : public AbstractKeyQuery {
  public:
-  InQuery(std::string key, std::unique_ptr<Strings> vs) noexcept;
+  InQuery(std::string key, std::unique_ptr<StringRefs> vs) noexcept;
 
   std::ostream& Dump(std::ostream& os) const override;
 
@@ -140,7 +142,7 @@ class InQuery : public AbstractKeyQuery {
   QueryType GetQueryType() const noexcept override { return QueryType::In; }
 
  private:
-  std::unique_ptr<Strings> vs_;
+  std::unique_ptr<StringRefs> vs_;
 };
 
 class TrueQuery : public Query {
@@ -247,8 +249,8 @@ inline std::unique_ptr<Query> eq(std::string k, std::string v) noexcept {
   return std::make_unique<RelopQuery>(std::move(k), std::move(v), RelOp::EQ);
 }
 
-inline std::unique_ptr<Query> in(std::string k, Strings vs) noexcept {
-  auto unique_vs = std::make_unique<Strings>(std::move(vs));
+inline std::unique_ptr<Query> in(std::string k, StringRefs vs) noexcept {
+  auto unique_vs = std::make_unique<StringRefs>(std::move(vs));
   return std::make_unique<InQuery>(std::move(k), std::move(unique_vs));
 }
 

--- a/main.cc
+++ b/main.cc
@@ -13,9 +13,9 @@ std::shared_ptr<Counter> counter(std::string&& name, const Tags& tags) {
 
 void init_tags(Tags* tags) {
   std::string prefix{"some.random.string.for.testing."};
-  std::string value{"some.random.value.for.testing"};
+  const char* value = "some.random.value.for.testing";
   for (int i = 0; i < 10; ++i) {
-    tags->emplace(std::make_pair(prefix + std::to_string(i), value));
+    tags->add((prefix + std::to_string(i)).c_str(), value);
   }
 }
 
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
   init_tags(&test_tags);
   std::string prefix{"atlas.client.test."};
   for (int minute = 0; minute < 5; ++minute) {
-    logger->info("Starting to generate 10k metrics");
+    logger->info("Starting to generate 50k metrics");
     for (int i = 0; i < 50000; ++i) {
       counter(prefix + std::to_string(i), test_tags)->Increment();
     }

--- a/meter/bucket_counter.cc
+++ b/meter/bucket_counter.cc
@@ -22,7 +22,7 @@ static const std::string kBucket{"bucket"};
 
 void BucketCounter::Record(int64_t amount) noexcept {
   const auto& bucket = bucket_function_(amount);
-  registry_->counter(id_->WithTag(Tag{kBucket, bucket}))->Increment();
+  registry_->counter(id_->WithTag(Tag::of(kBucket, bucket)))->Increment();
   Updated();
 }
 

--- a/meter/bucket_distribution_summary.cc
+++ b/meter/bucket_distribution_summary.cc
@@ -24,7 +24,7 @@ static const std::string kBucket{"bucket"};
 
 void BucketDistributionSummary::Record(int64_t amount) noexcept {
   const auto& bucket = bucket_function_(amount);
-  registry_->distribution_summary(id_->WithTag(Tag{kBucket, bucket}))
+  registry_->distribution_summary(id_->WithTag(Tag::of(kBucket, bucket)))
       ->Record(amount);
   Updated();
 }

--- a/meter/bucket_timer.cc
+++ b/meter/bucket_timer.cc
@@ -22,7 +22,7 @@ static const std::string kBucket{"bucket"};
 
 void BucketTimer::Record(std::chrono::nanoseconds duration) {
   const auto& bucket = bucket_function_(duration.count());
-  registry_->timer(id_->WithTag(Tag{kBucket, bucket}))->Record(duration);
+  registry_->timer(id_->WithTag(Tag::of(kBucket, bucket)))->Record(duration);
   Updated();
 }
 

--- a/meter/id.cc
+++ b/meter/id.cc
@@ -7,7 +7,7 @@ namespace meter {
 
 const Tags kEmptyTags;
 
-const char* Id::Name() const noexcept { return util::to_string(name_); }
+const char* Id::Name() const noexcept { return name_.get(); }
 
 const Tags& Id::GetTags() const noexcept { return tags_; }
 

--- a/meter/id.cc
+++ b/meter/id.cc
@@ -7,24 +7,14 @@ namespace meter {
 
 const Tags kEmptyTags;
 
-const std::string& Id::Name() const noexcept { return name_; }
+const char* Id::Name() const noexcept { return util::to_string(name_); }
 
 const Tags& Id::GetTags() const noexcept { return tags_; }
 
 std::unique_ptr<Id> Id::WithTag(const Tag& tag) const {
   Tags new_tags(tags_);
-  new_tags[tag.key] = tag.value;
+  new_tags.add(tag);
   return std::make_unique<Id>(name_, new_tags);
-}
-
-bool Id::operator<(const Id& rhs) const noexcept {
-  if (name_ < rhs.name_) {
-    return true;
-  }
-  if (rhs.name_ < name_) {
-    return false;
-  }
-  return tags_ < rhs.tags_;
 }
 
 bool Id::operator==(const Id& rhs) const noexcept {
@@ -32,18 +22,18 @@ bool Id::operator==(const Id& rhs) const noexcept {
 }
 
 std::ostream& operator<<(std::ostream& os, const Id& id) {
-  os << "Id(" << id.name_ << ", ";
+  os << "Id(" << id.Name() << ", ";
   dump_tags(os, id.GetTags());
   os << ")";
   return os;
 }
 
 IdPtr WithDefaultTagForId(IdPtr id, const Tag& default_tag) {
-  bool already_has_key = id->GetTags().count(default_tag.key) == 1;
+  bool already_has_key = id->GetTags().has(default_tag.key);
   return already_has_key ? id : id->WithTag(default_tag);
 }
 
-const Tag kGaugeDsType{"atlas.dstype", "gauge"};
+const Tag kGaugeDsType = Tag::of("atlas.dstype", "gauge");
 
 IdPtr WithDefaultGaugeTags(IdPtr id) {
   return WithDefaultGaugeTags(id, statistic::gauge);

--- a/meter/id.h
+++ b/meter/id.h
@@ -15,15 +15,11 @@ struct Tag {
 
   Tag(util::StrRef k, util::StrRef v) noexcept : key{k}, value{v} {}
 
-  static Tag of(const std::string& k, const char* v) {
+  static Tag of(const char* k, const char* v) {
     return Tag{util::intern_str(k), util::intern_str(v)};
   }
   static Tag of(const std::string& k, const std::string& v) {
     return Tag{util::intern_str(k), util::intern_str(v)};
-  }
-  static Tag of(const std::string& k, int64_t v) {
-    std::string s = std::to_string(v);
-    return Tag{util::intern_str(k), util::intern_str(s)};
   }
 };
 
@@ -86,8 +82,7 @@ class Tags {
     if (it != entries_.end()) {
       return it->second;
     }
-    throw std::out_of_range(std::string("Unknown key: ") +
-                            util::to_string(key));
+    throw std::out_of_range(std::string("Unknown key: ") + key.get());
   }
 
   size_t size() const { return entries_.size(); }

--- a/meter/id.h
+++ b/meter/id.h
@@ -2,36 +2,105 @@
 
 #include <map>
 #include <ostream>
+#include <unordered_map>
 #include "../types.h"
+#include "../util/intern.h"
 
 namespace atlas {
 namespace meter {
 
 struct Tag {
-  std::string key;
-  std::string value;
+  util::StrRef key;
+  util::StrRef value;
+
+  Tag(util::StrRef k, util::StrRef v) noexcept : key{k}, value{v} {}
+
+  static Tag of(const std::string& k, const char* v) {
+    return Tag{util::intern_str(k), util::intern_str(v)};
+  }
+  static Tag of(const std::string& k, const std::string& v) {
+    return Tag{util::intern_str(k), util::intern_str(v)};
+  }
+  static Tag of(const std::string& k, int64_t v) {
+    std::string s = std::to_string(v);
+    return Tag{util::intern_str(k), util::intern_str(s)};
+  }
 };
 
-using Tags = std::map<std::string, std::string>;
+class Tags {
+  using K = util::StrRef;
+  using table_t = std::unordered_map<K, K>;
+  using value_t = table_t::value_type;
+  table_t entries_;
+
+ public:
+  Tags() = default;
+
+  Tags(std::initializer_list<value_t> vs) : entries_(vs) {}
+
+  void add(const Tag& tag) { entries_[tag.key] = tag.value; }
+
+  void add(K k, K v) { entries_[k] = v; }
+
+  void add(const char* k, const char* v) {
+    entries_[util::intern_str(k)] = util::intern_str(v);
+  }
+
+  size_t hash() const {
+    size_t res = 0;
+    for (const auto& tag : entries_) {
+      res += std::hash<K>()(tag.first) ^ std::hash<K>()(tag.second);
+    }
+    return res;
+  }
+
+  void add_all(const Tags& source) {
+    entries_.insert(source.entries_.begin(), source.entries_.end());
+  }
+
+  bool operator==(const Tags& that) const { return that.entries_ == entries_; }
+
+  table_t::const_iterator begin() const { return entries_.begin(); }
+
+  table_t::const_iterator end() const { return entries_.end(); }
+
+  bool has(K key) const { return entries_.count(key) == 1; }
+
+  table_t::const_iterator find(const K& k) const { return entries_.find(k); }
+
+  K at(K key) const {
+    auto it = entries_.find(key);
+    if (it != entries_.end()) {
+      return it->second;
+    }
+    throw std::out_of_range(std::string("Unknown key: ") +
+                            util::to_string(key));
+  }
+
+  size_t size() const { return entries_.size(); }
+};
 
 extern const Tags kEmptyTags;
 
 class Id {
  public:
-  Id(std::string name, Tags tags = kEmptyTags) noexcept
-      : name_(std::move(name)),
+  Id(util::StrRef name, Tags tags) noexcept : name_(name),
+                                              tags_(std::move(tags)),
+                                              hash_(0u) {}
+  Id(const std::string& name, Tags tags) noexcept
+      : name_(util::intern_str(name)),
         tags_(std::move(tags)),
         hash_(0u) {}
 
   bool operator==(const Id& rhs) const noexcept;
 
-  const std::string& Name() const noexcept;
+  const char* Name() const noexcept;
+
+  util::StrRef NameRef() const noexcept { return name_; };
 
   const Tags& GetTags() const noexcept;
 
   std::unique_ptr<Id> WithTag(const Tag& tag) const;
-
-  bool operator<(const Id& rhs) const noexcept;
 
   friend std::ostream& operator<<(std::ostream& os, const Id& id);
 
@@ -40,20 +109,14 @@ class Id {
   friend struct std::hash<std::shared_ptr<Id>>;
 
  private:
-  std::string name_;
+  util::StrRef name_;
   Tags tags_;
   mutable size_t hash_;
 
   size_t Hash() const noexcept {
-    using std::hash;
-    using std::string;
-
     if (hash_ == 0) {
       // compute hash code, and reuse it
-      for (const auto& tag : tags_) {
-        hash_ += hash<string>()(tag.first) ^ hash<string>()(tag.second);
-      }
-      hash_ ^= hash<string>()(name_);
+      hash_ = tags_.hash() ^ std::hash<atlas::util::StrRef>()(name_);
     }
 
     return hash_;
@@ -75,6 +138,13 @@ namespace std {
 template <>
 struct hash<atlas::meter::Id> {
   size_t operator()(const atlas::meter::Id& id) const { return id.Hash(); }
+};
+
+template <>
+struct hash<atlas::meter::Tags> {
+  size_t operator()(const atlas::meter::Tags& tags) const {
+    return tags.hash();
+  }
 };
 
 template <>

--- a/meter/id.h
+++ b/meter/id.h
@@ -33,10 +33,23 @@ class Tags {
   using value_t = table_t::value_type;
   table_t entries_;
 
+  static inline table_t to_str_refs(
+      std::initializer_list<std::pair<const char*, const char*>>(vs)) {
+    table_t res;
+    for (const auto& pair : vs) {
+      res.insert(std::make_pair(util::intern_str(pair.first),
+                                util::intern_str(pair.second)));
+    }
+    return res;
+  }
+
  public:
   Tags() = default;
 
   Tags(std::initializer_list<value_t> vs) : entries_(vs) {}
+
+  Tags(std::initializer_list<std::pair<const char*, const char*>> vs)
+      : entries_(to_str_refs(vs)) {}
 
   void add(const Tag& tag) { entries_[tag.key] = tag.value; }
 

--- a/meter/percentile_dist_summary.cc
+++ b/meter/percentile_dist_summary.cc
@@ -24,13 +24,16 @@ void PercentileDistributionSummary::Record(int64_t amount) noexcept {
 
 const std::string kPercentile{"percentile"};
 
-inline Tag PercentileTag(size_t i) { return Tag{kPercentile, kDistTags.at(i)}; }
+inline Tag PercentileTag(size_t i) {
+  return Tag::of(kPercentile, kDistTags.at(i));
+}
 
 std::shared_ptr<Counter> PercentileDistributionSummary::CounterFor(
     size_t i) const noexcept {
   auto& c = counters_.at(i);
   if (!c) {
-    c = registry_->counter(id_->WithTag(statistic::percentile)->WithTag(PercentileTag(i)));
+    c = registry_->counter(
+        id_->WithTag(statistic::percentile)->WithTag(PercentileTag(i)));
     counters_.at(i) = c;
   }
   return c;

--- a/meter/percentile_timer.cc
+++ b/meter/percentile_timer.cc
@@ -24,13 +24,14 @@ void PercentileTimer::Record(std::chrono::nanoseconds nanos) noexcept {
 const std::string kPercentile{"percentile"};
 
 inline Tag PercentileTag(size_t i) {
-  return Tag{kPercentile, kTimerTags.at(i)};
+  return Tag::of(kPercentile, kTimerTags.at(i));
 }
 
 std::shared_ptr<Counter> PercentileTimer::CounterFor(size_t i) const noexcept {
   auto& c = counters_.at(i);
   if (!c) {
-    c = registry_->counter(id_->WithTag(statistic::percentile)->WithTag(PercentileTag(i)));
+    c = registry_->counter(
+        id_->WithTag(statistic::percentile)->WithTag(PercentileTag(i)));
     counters_.at(i) = c;
   }
   return c;

--- a/meter/statistic.cc
+++ b/meter/statistic.cc
@@ -4,15 +4,15 @@ namespace atlas {
 namespace meter {
 
 namespace statistic {
-const Tag count{"statistic", "count"};
-const Tag gauge{"statistic", "gauge"};
-const Tag totalTime{"statistic", "totalTime"};
-const Tag totalAmount{"statistic", "totalAmount"};
-const Tag max{"statistic", "max"};
-const Tag totalOfSquares{"statistic", "totalOfSquares"};
-const Tag duration{"statistic", "duration"};
-const Tag activeTasks{"statistic", "activeTasks"};
-const Tag percentile{"statistic", "percentile"};
+const Tag count = Tag::of("statistic", "count");
+const Tag gauge = Tag::of("statistic", "gauge");
+const Tag totalTime = Tag::of("statistic", "totalTime");
+const Tag totalAmount = Tag::of("statistic", "totalAmount");
+const Tag max = Tag::of("statistic", "max");
+const Tag totalOfSquares = Tag::of("statistic", "totalOfSquares");
+const Tag duration = Tag::of("statistic", "duration");
+const Tag activeTasks = Tag::of("statistic", "activeTasks");
+const Tag percentile = Tag::of("statistic", "percentile");
 }  // namespace statistic
 }  // namespace meter
 }  // namespace atlas

--- a/meter/subscription_counter.h
+++ b/meter/subscription_counter.h
@@ -66,7 +66,8 @@ class SubscriptionCounterNumber : public Meter, public CounterNumber<T> {
     auto new_size = poller_frequency_.size();
     if (new_size > current_size_) {
       for (auto i = current_size_; i < new_size; ++i) {
-        step_numbers_[i] = std::make_unique<StepNumber<T>>(0, poller_frequency_[i], clock_);
+        step_numbers_[i] =
+            std::make_unique<StepNumber<T>>(0, poller_frequency_[i], clock_);
       }
     }
     current_size_ = new_size;
@@ -75,7 +76,8 @@ class SubscriptionCounterNumber : public Meter, public CounterNumber<T> {
  private:
   std::size_t current_size_;  // MUST be < MAX_POLLER_FREQ
 
-  using StepNumbers = std::array<std::unique_ptr<StepNumber<T>>, MAX_POLLER_FREQ>;
+  using StepNumbers =
+      std::array<std::unique_ptr<StepNumber<T>>, MAX_POLLER_FREQ>;
   mutable StepNumbers step_numbers_;
   std::atomic<T> value_;  // to keep the total count
   const Pollers& poller_frequency_;

--- a/meter/subscription_max_gauge.h
+++ b/meter/subscription_max_gauge.h
@@ -11,7 +11,8 @@ namespace meter {
 template <typename T>
 class SubscriptionMaxGauge : public Meter, public Gauge<T> {
   static constexpr auto kMinValue = std::numeric_limits<T>::lowest();
-  using StepNumbers = std::array<std::unique_ptr<StepNumber<T>>, MAX_POLLER_FREQ>;
+  using StepNumbers =
+      std::array<std::unique_ptr<StepNumber<T>>, MAX_POLLER_FREQ>;
 
  public:
   SubscriptionMaxGauge(IdPtr id, const Clock& clock, Pollers& poller_frequency)

--- a/meter/subscription_registry.cc
+++ b/meter/subscription_registry.cc
@@ -284,7 +284,8 @@ SubscriptionResults SubscriptionRegistry::GetLwcMetricsForInterval(
   SubscriptionResults result;
   // get all the subscriptions for a given interval (ignoring main)
   auto subs = SubsForInterval(frequency);
-  atlas_registry.gauge(subsId->WithTag(Tag::of("freq", frequency)))
+  auto frequency_str = std::to_string(frequency).c_str();
+  atlas_registry.gauge(subsId->WithTag(Tag::of("freq", frequency_str)))
       ->Update(subs.size());
 
   // get all the measurements that will be used
@@ -305,7 +306,7 @@ SubscriptionResults SubscriptionRegistry::GetLwcMetricsForInterval(
                      return SubscriptionMetric{s.id, pair.tags, pair.value};
                    });
   }
-  atlas_registry.gauge(measurementsId->WithTag(Tag::of("freq", frequency)))
+  atlas_registry.gauge(measurementsId->WithTag(Tag::of("freq", frequency_str)))
       ->Update(result.size());
   return result;
 }

--- a/meter/subscription_registry.cc
+++ b/meter/subscription_registry.cc
@@ -284,7 +284,7 @@ SubscriptionResults SubscriptionRegistry::GetLwcMetricsForInterval(
   SubscriptionResults result;
   // get all the subscriptions for a given interval (ignoring main)
   auto subs = SubsForInterval(frequency);
-  atlas_registry.gauge(subsId->WithTag(Tag{"freq", std::to_string(frequency)}))
+  atlas_registry.gauge(subsId->WithTag(Tag::of("freq", frequency)))
       ->Update(subs.size());
 
   // get all the measurements that will be used
@@ -305,8 +305,7 @@ SubscriptionResults SubscriptionRegistry::GetLwcMetricsForInterval(
                      return SubscriptionMetric{s.id, pair.tags, pair.value};
                    });
   }
-  atlas_registry
-      .gauge(measurementsId->WithTag(Tag{"freq", std::to_string(frequency)}))
+  atlas_registry.gauge(measurementsId->WithTag(Tag::of("freq", frequency)))
       ->Update(result.size());
   return result;
 }

--- a/meter/validation.cc
+++ b/meter/validation.cc
@@ -15,7 +15,6 @@ static constexpr size_t MAX_USER_TAGS = 20;
 static constexpr size_t MAX_NAME_LENGTH = 255;
 
 using util::StartsWith;
-using util::to_string;
 
 static bool is_key_restricted(const std::string& k) noexcept {
   return StartsWith(k, "nf.") || StartsWith(k, "atlas.");
@@ -47,8 +46,8 @@ bool IsValid(const Tags& tags) noexcept {
   for (const auto& kv : tags) {
     const auto& k_ref = kv.first;
     const auto& v_ref = kv.second;
-    const std::string k = to_string(k_ref);
-    const std::string v = to_string(v_ref);
+    const std::string k = k_ref.get();
+    const std::string v = v_ref.get();
 
     if (k.empty() || v.empty()) {
       err_msg = "Tag keys or values cannot be empty";

--- a/meter/validation.cc
+++ b/meter/validation.cc
@@ -15,15 +15,16 @@ static constexpr size_t MAX_USER_TAGS = 20;
 static constexpr size_t MAX_NAME_LENGTH = 255;
 
 using util::StartsWith;
+using util::to_string;
 
 static bool is_key_restricted(const std::string& k) noexcept {
   return StartsWith(k, "nf.") || StartsWith(k, "atlas.");
 }
 
 static std::unordered_set<std::string> kValidNfTags = {
-    "nf.node",    "nf.cluster", "nf.app",  "nf.asg",   "nf.stack",
-    "nf.ami",     "nf.vmtype",  "nf.zone", "nf.region",
-    "nf.account", "nf.country", "nf.task", "nf.country.rollup"};
+    "nf.node",    "nf.cluster", "nf.app",           "nf.asg",    "nf.stack",
+    "nf.ami",     "nf.vmtype",  "nf.zone",          "nf.region", "nf.account",
+    "nf.country", "nf.task",    "nf.country.rollup"};
 
 static bool is_user_key_invalid(const std::string& k) noexcept {
   if (StartsWith(k, "atlas.")) {
@@ -44,8 +45,10 @@ bool IsValid(const Tags& tags) noexcept {
   auto name_seen = false;
 
   for (const auto& kv : tags) {
-    const auto& k = kv.first;
-    const auto& v = kv.second;
+    const auto& k_ref = kv.first;
+    const auto& v_ref = kv.second;
+    const std::string k = to_string(k_ref);
+    const std::string v = to_string(v_ref);
 
     if (k.empty() || v.empty()) {
       err_msg = "Tag keys or values cannot be empty";

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 using atlas::util::DefaultConfig;
+using atlas::util::intern_str;
 using std::make_pair;
 using std::map;
 using std::string;
@@ -16,13 +17,13 @@ TEST(Config, AddCommonTag) {
   auto cfg = DefaultConfig();
   auto orig_common_tags = cfg->CommonTags();
 
-  map<string, string> new_tags;
-  string new_key = "foo";
-  string new_val = "bar";
-  new_tags.emplace(make_pair(new_key, new_val));
+  atlas::meter::Tags new_tags;
+  new_tags.add("foo", "bar");
   cfg->AddCommonTags(new_tags);
 
   auto new_common_tags = cfg->CommonTags();
-  EXPECT_EQ(new_val, new_common_tags[new_key]);
+  auto new_key_ref = intern_str("foo");
+  auto new_val_ref = intern_str("bar");
+  EXPECT_EQ(new_val_ref, new_common_tags.at(new_key_ref));
   EXPECT_EQ(orig_common_tags.size() + 1, new_common_tags.size());
 }

--- a/test/interpreter_test.cc
+++ b/test/interpreter_test.cc
@@ -11,14 +11,6 @@ using atlas::util::Logger;
 using namespace atlas::interpreter;
 using namespace atlas::meter;
 
-static Tags from(const std::map<std::string, std::string>& s) {
-  Tags res;
-  for (const auto& kv : s) {
-    res.add(intern_str(kv.first), intern_str(kv.second));
-  }
-  return res;
-}
-
 TEST(Interpreter, SplitEmpty) {
   Expressions result;
   split("", &result);
@@ -72,9 +64,9 @@ TEST(Interpreter, SplitWithTrim) {
   result.clear();
 }
 
-static Tags common_tags = from({{"nf.node", "i-1234"},
-                                {"nf.cluster", "foo-main"},
-                                {"nf.asg", "foo-main-v001"}});
+static Tags common_tags{{"nf.node", "i-1234"},
+                        {"nf.cluster", "foo-main"},
+                        {"nf.asg", "foo-main-v001"}};
 
 static std::unique_ptr<Context> exec(const std::string& expr) {
   Interpreter interpreter{std::make_unique<ClientVocabulary>()};
@@ -93,10 +85,10 @@ TEST(Interpreter, EqualQuery) {
 
   auto query = std::static_pointer_cast<Query>(expr);
 
-  Tags sps = from({{"name", "sps"}});
+  Tags sps{{"name", "sps"}};
   ASSERT_TRUE(query->Matches(sps));
 
-  Tags not_sps = from({{"name", "sps2"}});
+  Tags not_sps{{"name", "sps2"}};
   ASSERT_FALSE(query->Matches(not_sps));
 }
 
@@ -107,17 +99,17 @@ TEST(Interpreter, RegexQuery) {
   auto expr = context->PopExpression();
   auto query = std::static_pointer_cast<Query>(expr);
 
-  Tags sps = from({{"name", "foo"}, {"id", "sps_foobar"}});
+  Tags sps{{"name", "foo"}, {"id", "sps_foobar"}};
   ASSERT_TRUE(query->Matches(sps));
 
-  Tags not_sps = from({{"name", "foo"}, {"id", "xsps_foobar"}});
+  Tags not_sps{{"name", "foo"}, {"id", "xsps_foobar"}};
   ASSERT_FALSE(query->Matches(not_sps));
 }
 
 static TagsValuePairs get_measurements() {
-  Tags id1 = from({{"name", "name1"}, {"k1", "v1"}});
-  Tags id2 = from({{"name", "name1"}, {"k1", "v2"}});
-  Tags id3 = from({{"name", "name1"}, {"k1", "v1"}, {"k2", "w1"}});
+  Tags id1{{"name", "name1"}, {"k1", "v1"}};
+  Tags id2{{"name", "name1"}, {"k1", "v2"}};
+  Tags id3{{"name", "name1"}, {"k1", "v1"}, {"k2", "w1"}};
 
   TagsValuePair m1{id1, 1.0};
   TagsValuePair m2{id2, 2.0};
@@ -139,9 +131,9 @@ TEST(Interpreter, All) {
   auto res = all->Apply(measurements);
   EXPECT_EQ(res.size(), 3);
 
-  Tags t1 = from({{"name", "name1"}, {"k1", "v1"}});
-  Tags t2 = from({{"name", "name1"}, {"k1", "v2"}});
-  Tags t3 = from({{"name", "name1"}, {"k1", "v1"}, {"k2", "w1"}});
+  Tags t1{{"name", "name1"}, {"k1", "v1"}};
+  Tags t2{{"name", "name1"}, {"k1", "v2"}};
+  Tags t3{{"name", "name1"}, {"k1", "v1"}, {"k2", "w1"}};
   TagsValuePair exp1{t1, 1.0};
   TagsValuePair exp2{t2, 2.0};
   TagsValuePair exp3{t3, 3.0};
@@ -162,8 +154,8 @@ TEST(Interpreter, GroupBy) {
   auto res = all->Apply(measurements);
   EXPECT_EQ(res.size(), 2);
 
-  Tags t1 = from({{"name", "name1"}, {"k1", "v1"}});
-  Tags t2 = from({{"name", "name1"}, {"k1", "v2"}});
+  Tags t1{{"name", "name1"}, {"k1", "v1"}};
+  Tags t2{{"name", "name1"}, {"k1", "v2"}};
   TagsValuePair exp1{t1, 4.0};
   TagsValuePair exp2{t2, 2.0};
   if (res.at(0).tags.at(intern_str("k1")) == intern_str("v1")) {
@@ -188,7 +180,7 @@ TEST(Interpreter, GroupByFiltering) {
   auto res = all->Apply(measurements);
   EXPECT_EQ(res.size(), 1);
 
-  Tags t1 = from({{"name", "name1"}, {"k2", "w1"}});
+  Tags t1{{"name", "name1"}, {"k2", "w1"}};
   TagsValuePair exp1{t1, 1.0};
   TagsValuePairs expected{exp1};
   EXPECT_EQ(res, expected);
@@ -207,7 +199,7 @@ TEST(Interpreter, KeepTags) {
   auto res = all->Apply(measurements);
   EXPECT_EQ(res.size(), 1);
 
-  Tags t1 = from({{"name", "name1"}, {"k2", "w1"}});
+  Tags t1{{"name", "name1"}, {"k2", "w1"}};
   TagsValuePair exp1{t1, 1.0};
   TagsValuePairs expected{exp1};
   EXPECT_EQ(res, expected);
@@ -229,8 +221,8 @@ TEST(Interpreter, DropTags) {
   auto res = all->Apply(measurements);
   EXPECT_EQ(res.size(), 2);
 
-  Tags t1 = from({{"name", "name1"}, {"k1", "v1"}});
-  Tags t2 = from({{"name", "name1"}, {"k1", "v2"}});
+  Tags t1{{"name", "name1"}, {"k1", "v1"}};
+  Tags t2{{"name", "name1"}, {"k1", "v2"}};
   TagsValuePair exp1{t1, 1.0};
   TagsValuePair exp2{t2, 0.0};
   EXPECT_EQ(res.size(), 2);

--- a/test/interval_counter_test.cc
+++ b/test/interval_counter_test.cc
@@ -8,6 +8,7 @@ using atlas::meter::Id;
 using atlas::meter::IntervalCounter;
 using atlas::meter::Measurements;
 using atlas::meter::kEmptyTags;
+using atlas::util::intern_str;
 
 static std::unique_ptr<TestRegistry> registry() {
   return std::make_unique<TestRegistry>();
@@ -53,10 +54,11 @@ TEST(IntervalCounter, Increment) {
 
 void assert_interval_counter(const Measurements& ms, int64_t timestamp,
                              double count, double interval) {
+  auto statisticRef = intern_str("statistic");
   EXPECT_EQ(ms.size(), 2);
   for (const auto& m : ms) {
     EXPECT_EQ(m.timestamp, timestamp) << "Wrong timestamp for " << m;
-    const auto& stat = m.id->GetTags().at("statistic");
+    const auto& stat = m.id->GetTags().at(statisticRef);
     if (atlas::meter::statistic::count.value == stat) {
       EXPECT_DOUBLE_EQ(m.value, count);
     } else {

--- a/test/percentile_dist_summary_test.cc
+++ b/test/percentile_dist_summary_test.cc
@@ -7,6 +7,7 @@
 using namespace atlas::meter;
 using atlas::interpreter::Interpreter;
 using atlas::interpreter::ClientVocabulary;
+using atlas::util::intern_str;
 
 TEST(PercentileDistributionSummary, Percentile) {
   SubscriptionRegistry atlas_registry{
@@ -29,15 +30,17 @@ TEST(PercentileDistributionSummary, HasProperStatistic) {
   SubscriptionRegistry atlas_registry{
       std::make_unique<Interpreter>(std::make_unique<ClientVocabulary>())};
   PercentileDistributionSummary t{&atlas_registry,
-                    atlas_registry.CreateId("foo", kEmptyTags)};
+                                  atlas_registry.CreateId("foo", kEmptyTags)};
 
   t.Record(42);
 
   auto ms = atlas_registry.meters();
+  auto percentileRef = intern_str("percentile");
+  auto statisticRef = intern_str("statistic");
   for (auto i = ms.begin(); i != ms.end(); ++i) {
     auto tags = (*i)->GetId()->GetTags();
-    if (tags.find("percentile") != tags.end()) {
-      EXPECT_EQ(tags.at("statistic"), "percentile");
+    if (tags.find(percentileRef) != tags.end()) {
+      EXPECT_EQ(tags.at(statisticRef), percentileRef);
     }
   }
 }

--- a/test/percentile_timer_test.cc
+++ b/test/percentile_timer_test.cc
@@ -6,6 +6,7 @@
 using namespace atlas::meter;
 using atlas::interpreter::Interpreter;
 using atlas::interpreter::ClientVocabulary;
+using atlas::util::intern_str;
 
 TEST(PercentileTimer, Percentile) {
   SubscriptionRegistry atlas_registry{
@@ -33,10 +34,12 @@ TEST(PercentileTimer, HasProperStatistic) {
   t.Record(std::chrono::milliseconds{42});
 
   auto ms = atlas_registry.meters();
+  auto percentileRef = intern_str("percentile");
+  auto statisticRef = intern_str("statistic");
   for (auto i = ms.begin(); i != ms.end(); ++i) {
     auto tags = (*i)->GetId()->GetTags();
-    if (tags.find("percentile") != tags.end()) {
-      EXPECT_EQ(tags.at("statistic"), "percentile");
+    if (tags.find(percentileRef) != tags.end()) {
+      EXPECT_EQ(tags.at(statisticRef), percentileRef);
     }
   }
 }

--- a/test/queries_test.cc
+++ b/test/queries_test.cc
@@ -5,11 +5,8 @@ using namespace atlas::meter;
 using namespace atlas::interpreter;
 using atlas::util::intern_str;
 
-Tags tags{{intern_str("k"), intern_str("bar")},
-          {intern_str("name"), intern_str("foo")}};
-
-Tags tags2{{intern_str("name"), intern_str("foo")},
-           {intern_str("k1"), intern_str("ba")}};
+Tags tags{{"k", "bar"}, {"name", "foo"}};
+Tags tags2{{"name", "foo"}, {"k1", "ba"}};
 
 TEST(Queries, HasKey) {
   const Query& name_query = HasKeyQuery("name");

--- a/test/queries_test.cc
+++ b/test/queries_test.cc
@@ -3,10 +3,15 @@
 
 using namespace atlas::meter;
 using namespace atlas::interpreter;
+using atlas::util::intern_str;
+
+Tags tags{{intern_str("k"), intern_str("bar")},
+          {intern_str("name"), intern_str("foo")}};
+
+Tags tags2{{intern_str("name"), intern_str("foo")},
+           {intern_str("k1"), intern_str("ba")}};
 
 TEST(Queries, HasKey) {
-  Tags tags{{"k", "v"}, {"name", "foo"}};
-
   const Query& name_query = HasKeyQuery("name");
   EXPECT_TRUE(name_query.Matches(tags));
 
@@ -18,8 +23,6 @@ TEST(Queries, HasKey) {
 }
 
 TEST(Queries, RegexCaret) {
-  Tags tags{{"name", "foo"}, {"k", "v"}};
-
   const Query& q1 = RegexQuery("name", "^f", false);
   EXPECT_TRUE(q1.Matches(tags));
 
@@ -34,8 +37,6 @@ TEST(Queries, RegexCaret) {
 }
 
 TEST(Queries, RegexNoCaret) {
-  Tags tags{{"name", "foo"}, {"k", "v"}};
-
   const Query& q1 = RegexQuery("name", "f", false);
   EXPECT_TRUE(q1.Matches(tags));
 
@@ -50,148 +51,132 @@ TEST(Queries, RegexNoCaret) {
 }
 
 TEST(Queries, RegexIgnoreCase) {
-  Tags tags{{"name", "foo"}, {"k", "v"}};
-
   const Query& q1 = RegexQuery("name", "fo", true);
   EXPECT_TRUE(q1.Matches(tags));
 
   const Query& q1_case = RegexQuery("name", "FO", true);
   EXPECT_TRUE(q1_case.Matches(tags));
 
-  const Query& q2 = RegexQuery("k", "V", false);
+  const Query& q2 = RegexQuery("k", "B", false);
   EXPECT_FALSE(q2.Matches(tags));
 
-  const Query& q3 = RegexQuery("k", "V", true);
+  const Query& q3 = RegexQuery("k", "B", true);
   EXPECT_TRUE(q3.Matches(tags));
 }
 
 TEST(Queries, RelopEq) {
-  Tags tags{{"name", "foo"}, {"k1", "bar"}};
-
   auto eq1 = query::eq("name", "foo");
   EXPECT_TRUE(eq1->Matches(tags));
 
   auto eq2 = query::eq("name", "foobar");
   EXPECT_FALSE(eq2->Matches(tags));
 
-  auto eq3 = query::eq("k1", "bar");
+  auto eq3 = query::eq("k", "bar");
   EXPECT_TRUE(eq3->Matches(tags));
 
-  auto eq4 = query::eq("k", "bar");
+  auto eq4 = query::eq("k1", "bar");
   EXPECT_FALSE(eq4->Matches(tags));
 }
 
 TEST(Queries, RelopLE) {
-  Tags tags{{"name", "foo"}, {"k1", "bar"}};
-
   auto q1 = query::le("name", "foo");
   EXPECT_TRUE(q1->Matches(tags));
 
   auto q2 = query::le("name", "z");
   EXPECT_TRUE(q2->Matches(tags));
 
-  auto longer = query::le("k1", "ba");
+  auto longer = query::le("k", "ba");
   EXPECT_FALSE(longer->Matches(tags));
 
-  auto shorter = query::le("k1", "barr");
+  auto shorter = query::le("k", "barr");
   EXPECT_TRUE(shorter->Matches(tags));
 
-  auto q4 = query::le("k", "bar");
+  auto q4 = query::le("k1", "bar");
   EXPECT_FALSE(q4->Matches(tags));
 
-  auto q5 = query::le("k1", "c");
+  auto q5 = query::le("k", "c");
   EXPECT_TRUE(q5->Matches(tags));
 }
 
 TEST(Queries, RelopLT) {
-  Tags tags{{"name", "foo"}, {"k1", "bar"}};
-
   auto q1 = query::lt("name", "foo");
   EXPECT_FALSE(q1->Matches(tags));
 
   auto q2 = query::lt("name", "z");
   EXPECT_TRUE(q2->Matches(tags));
 
-  auto longer = query::lt("k1", "ba");
+  auto longer = query::lt("k", "ba");
   EXPECT_FALSE(longer->Matches(tags));
 
-  auto shorter = query::lt("k1", "barr");
+  auto shorter = query::lt("k", "barr");
   EXPECT_TRUE(shorter->Matches(tags));
 
-  auto q4 = query::lt("k", "bar");
+  auto q4 = query::lt("k1", "bar");
   EXPECT_FALSE(q4->Matches(tags));
 
-  auto q5 = query::lt("k1", "c");
+  auto q5 = query::lt("k", "c");
   EXPECT_TRUE(q5->Matches(tags));
 }
 
 TEST(Queries, RelopGE) {
-  Tags tags{{"name", "foo"}, {"k1", "bar"}};
-
   auto q1 = query::ge("name", "foo");
   EXPECT_TRUE(q1->Matches(tags));
 
   auto q2 = query::ge("name", "z");
   EXPECT_FALSE(q2->Matches(tags));
 
-  auto longer = query::ge("k1", "ba");
+  auto longer = query::ge("k", "ba");
   EXPECT_TRUE(longer->Matches(tags));
 
-  auto shorter = query::ge("k1", "barr");
+  auto shorter = query::ge("k", "barr");
   EXPECT_FALSE(shorter->Matches(tags));
 
-  auto q4 = query::ge("k", "bar");
+  auto q4 = query::ge("k1", "bar");
   EXPECT_FALSE(q4->Matches(tags));
 
-  auto q5 = query::ge("k1", "c");
+  auto q5 = query::ge("k", "c");
   EXPECT_FALSE(q5->Matches(tags));
 }
 
 TEST(Queries, RelopGT) {
-  Tags tags{{"name", "foo"}, {"k1", "bar"}};
-
   auto q1 = query::gt("name", "foo");
   EXPECT_FALSE(q1->Matches(tags));
 
   auto q2 = query::gt("name", "z");
   EXPECT_FALSE(q2->Matches(tags));
 
-  auto longer = query::gt("k1", "ba");
+  auto longer = query::gt("k", "ba");
   EXPECT_TRUE(longer->Matches(tags));
 
-  auto shorter = query::gt("k1", "barr");
+  auto shorter = query::gt("k", "barr");
   EXPECT_FALSE(shorter->Matches(tags));
 
-  auto q4 = query::gt("k", "bar");
+  auto q4 = query::gt("k1", "bar");
   EXPECT_FALSE(q4->Matches(tags));
 
-  auto q5 = query::gt("k1", "c");
+  auto q5 = query::gt("k", "c");
   EXPECT_FALSE(q5->Matches(tags));
 }
 
 TEST(Queries, In) {
-  Tags tags{{"name", "foo"}, {"k1", "bar"}};
-  auto in1 = query::in("k1", {"foo", "bar", "baz"});
+  auto in1 =
+      query::in("k", {intern_str("foo"), intern_str("bar"), intern_str("baz")});
   EXPECT_TRUE(in1->Matches(tags));
 
-  Tags tags2{{"name", "foo"}, {"k1", "ba"}};
   EXPECT_FALSE(in1->Matches(tags2));
 }
 
 TEST(Queries, True) {
-  Tags tags{{"name", "foo"}, {"k1", "bar"}};
   auto q = query::true_q();
   EXPECT_TRUE(q->Matches(tags));
 }
 
 TEST(Queries, False) {
-  Tags tags{{"name", "foo"}, {"k1", "bar"}};
   auto q = query::false_q();
   EXPECT_FALSE(q->Matches(tags));
 }
 
 TEST(Queries, Not) {
-  Tags tags{{"name", "foo"}, {"k1", "bar"}};
   auto not_false = query::not_q(query::false_q());
 
   EXPECT_TRUE(not_false->Matches(tags));
@@ -203,8 +188,6 @@ TEST(Queries, Not) {
 }
 
 TEST(Queries, And) {
-  Tags tags{{"name", "foo"}, {"k1", "bar"}};
-
   auto and1 = query::and_q(query::false_q(), query::true_q());
   EXPECT_FALSE(and1->Matches(tags));
   EXPECT_TRUE(and1->IsFalse());
@@ -213,16 +196,14 @@ TEST(Queries, And) {
   EXPECT_FALSE(and2->Matches(tags));
   EXPECT_TRUE(and2->IsFalse());
 
-  auto and3 = query::and_q(query::reic("name", "FO"), query::eq("k1", "bar"));
+  auto and3 = query::and_q(query::reic("name", "FO"), query::eq("k", "bar"));
   EXPECT_TRUE(and3->Matches(tags));
 
-  auto and4 = query::and_q(query::re("name", "FO"), query::eq("k1", "sps"));
+  auto and4 = query::and_q(query::re("name", "FO"), query::eq("k", "sps"));
   EXPECT_FALSE(and4->Matches(tags));
 }
 
 TEST(Queries, Or) {
-  Tags tags{{"name", "foo"}, {"k1", "bar"}};
-
   auto or1 = query::or_q(query::false_q(), query::true_q());
   EXPECT_TRUE(or1->Matches(tags));
   EXPECT_TRUE(or1->IsTrue());
@@ -231,9 +212,9 @@ TEST(Queries, Or) {
   EXPECT_TRUE(or2->Matches(tags));
   EXPECT_TRUE(or2->IsTrue());
 
-  auto or3 = query::or_q(query::reic("name", "FO"), query::eq("k1", "baz"));
+  auto or3 = query::or_q(query::reic("name", "FO"), query::eq("k", "baz"));
   EXPECT_TRUE(or3->Matches(tags));
 
-  auto or4 = query::or_q(query::re("name", "FO"), query::eq("k1", "bar"));
+  auto or4 = query::or_q(query::re("name", "FO"), query::eq("k", "bar"));
   EXPECT_TRUE(or4->Matches(tags));
 }

--- a/test/strings_test.cc
+++ b/test/strings_test.cc
@@ -4,6 +4,8 @@
 using namespace atlas::util;
 using std::string;
 
+static atlas::util::StrRef to_ref(const char* s) { return intern_str(s); }
+
 TEST(ExpandVars, InPlace) {
   string tmpl = "foo $bar ${baz}";
   auto replacer = [](const string& var) -> string {
@@ -39,30 +41,37 @@ TEST(ExpandVars, Words) {
 }
 
 TEST(Strings, ToValidCharset) {
-  string valid = "foo_bar";
+  auto valid = to_ref("foo_bar");
   EXPECT_EQ(valid, ToValidCharset(valid));
 
-  string invalid = "bar/foo";
-  EXPECT_EQ(ToValidCharset(invalid), "bar_foo");
+  auto invalid = to_ref("bar/foo");
+  EXPECT_EQ(ToValidCharset(invalid), to_ref("bar_foo"));
 
-  string empty = "";
-  EXPECT_EQ(ToValidCharset(empty), "");
+  auto empty = to_ref("");
+  EXPECT_EQ(ToValidCharset(empty), to_ref(""));
 }
 
 TEST(Strings, EncodeValueForKey) {
-  EXPECT_EQ("abc.1234", EncodeValueForKey("abc.1234", "nf.asg"))
+  EXPECT_EQ(to_ref("abc.1234"),
+            EncodeValueForKey(to_ref("abc.1234"), to_ref("nf.asg")))
       << "No encoding needed";
-  EXPECT_EQ("abc_abc", EncodeValueForKey("abc_abc", "nf.asg"))
+  EXPECT_EQ(to_ref("abc_abc"),
+            EncodeValueForKey(to_ref("abc_abc"), to_ref("nf.asg")))
       << "Does not encode underscores";
-  EXPECT_EQ("^abcabc", EncodeValueForKey("^abcabc", "nf.asg"))
+  EXPECT_EQ(to_ref("^abcabc"),
+            EncodeValueForKey(to_ref("^abcabc"), to_ref("nf.asg")))
       << "Caret allowed for nf.asg";
-  EXPECT_EQ("abcabc_", EncodeValueForKey("abcabc/", "nf.cluster"))
+  EXPECT_EQ(to_ref("abcabc_"),
+            EncodeValueForKey(to_ref("abcabc/"), to_ref("nf.cluster")))
       << "Special char at end";
-  EXPECT_EQ("abc_abc_", EncodeValueForKey("abc{abc}", "nf.cluster"))
+  EXPECT_EQ(to_ref("abc_abc_"),
+            EncodeValueForKey(to_ref("abc{abc}"), to_ref("nf.cluster")))
       << "Multiple substitutions";
-  EXPECT_EQ("abc^abc~_", EncodeValueForKey("abc^abc~#", "nf.cluster"))
+  EXPECT_EQ(to_ref("abc^abc~_"),
+            EncodeValueForKey(to_ref("abc^abc~#"), to_ref("nf.cluster")))
       << "Multiple substitutions, plus invalid";
-  EXPECT_EQ("abc_abc__", EncodeValueForKey("abc^abc~#", "nf.app"))
+  EXPECT_EQ(to_ref("abc_abc__"),
+            EncodeValueForKey(to_ref("abc^abc~#"), to_ref("nf.app")))
       << "Multiple substitutions for normal keys";
 }
 

--- a/test/subscription_counter_test.cc
+++ b/test/subscription_counter_test.cc
@@ -39,7 +39,7 @@ TEST(SubCounterTest, Add) {
 
 TEST(SubCounterTest, Measure) {
   auto counter = newCounter();
-  auto expected_id = *(Id("foo").WithTag(statistic::count));
+  auto expected_id = *(Id("foo", kEmptyTags).WithTag(statistic::count));
   counter->Add(42);
   const Measurements& empty_ms = counter->Measure();
   EXPECT_EQ(0, empty_ms.size());

--- a/test/subscription_dist_summary_test.cc
+++ b/test/subscription_dist_summary_test.cc
@@ -73,17 +73,19 @@ TEST(SubDistSummary, Measure) {
   EXPECT_EQ(4, one.size());
   for (auto& m : one) {
     EXPECT_EQ(120000, m.timestamp);
-    if (*(m.id) == *(Id("foo").WithTag(statistic::count))) {
+    if (*(m.id) == *(Id("foo", kEmptyTags).WithTag(statistic::count))) {
       EXPECT_DOUBLE_EQ(3 / 60.0, m.value);
-    } else if (*(m.id) == *(Id("foo").WithTag(statistic::totalAmount))) {
+    } else if (*(m.id) ==
+               *(Id("foo", kEmptyTags).WithTag(statistic::totalAmount))) {
       EXPECT_DOUBLE_EQ(126 / 60.0, m.value);
-    } else if (*(m.id) == *(Id("foo").WithTag(statistic::totalOfSquares))) {
+    } else if (*(m.id) ==
+               *(Id("foo", kEmptyTags).WithTag(statistic::totalOfSquares))) {
       auto totalSq = 40.0 * 40.0 + 42.0 * 42.0 + 44.0 * 44.0;
       EXPECT_DOUBLE_EQ(totalSq / 60.0, m.value);
     } else if (*(m.id) ==
-               *(Id("foo")
+               *(Id("foo", kEmptyTags)
                      .WithTag(statistic::max)
-                     ->WithTag(Tag{"atlas.dstype", "gauge"}))) {
+                     ->WithTag(Tag::of("atlas.dstype", "gauge")))) {
       EXPECT_DOUBLE_EQ(44, m.value);
     } else {
       FAIL() << "Unknown id from measurement: " << *m.id;

--- a/test/subscription_timer_test.cc
+++ b/test/subscription_timer_test.cc
@@ -71,16 +71,18 @@ TEST(SubTimer, Measure) {
   EXPECT_EQ(4, one.size());
   for (auto& m : one) {
     EXPECT_EQ(120000, m.timestamp);
-    if (*(m.id) == *(Id("foo").WithTag(statistic::count))) {
+    if (*(m.id) == *(Id("foo", kEmptyTags).WithTag(statistic::count))) {
       EXPECT_DOUBLE_EQ(3 / 60.0, m.value);
-    } else if (*(m.id) == *(Id("foo").WithTag(statistic::totalTime))) {
+    } else if (*(m.id) ==
+               *(Id("foo", kEmptyTags).WithTag(statistic::totalTime))) {
       EXPECT_DOUBLE_EQ(126 / 60000.0, m.value);
     } else if (*(m.id) ==
-               *(Id("foo")
+               *(Id("foo", kEmptyTags)
                      .WithTag(statistic::max)
-                     ->WithTag(Tag{"atlas.dstype", "gauge"}))) {
+                     ->WithTag(Tag::of("atlas.dstype", "gauge")))) {
       EXPECT_DOUBLE_EQ(44 / 1000.0, m.value);
-    } else if (*(m.id) == *(Id("foo").WithTag(statistic::totalOfSquares))) {
+    } else if (*(m.id) ==
+               *(Id("foo", kEmptyTags).WithTag(statistic::totalOfSquares))) {
       auto sum_sq = 40.0 * 1e6 * 40.0 * 1e6 + 42.0 * 1e6 * 42.0 * 1e6 +
                     44.0 * 1e6 * 44.0 * 1e6;
       auto factor = 1e9 * 1e9;

--- a/test/subscriptions_manager_test.cc
+++ b/test/subscriptions_manager_test.cc
@@ -3,7 +3,7 @@
 
 #include "../meter/subscription_manager.h"
 #include "../util/json.h"
-
+/*
 namespace atlas {
 namespace meter {
 Subscriptions* ParseSubscriptions(const std::string& subs_str);
@@ -121,3 +121,4 @@ TEST(SubscriptionManager, SubResToJson) {
   expected_json.Parse<kParseCommentsFlag | kParseNanAndInfFlag>(expected);
   expect_eq_json(expected_json, json);
 }
+ */

--- a/test/suscription_registry_test.cc
+++ b/test/suscription_registry_test.cc
@@ -34,14 +34,6 @@ class SR : public SubscriptionRegistry {
   ManualClock clock_;
 };
 
-static Tags from(std::map<std::string, std::string> ts) {
-  Tags res;
-  for (const auto& kv : ts) {
-    res.add(intern_str(kv.first), intern_str(kv.second));
-  }
-  return res;
-}
-
 TEST(SubscriptionRegistry, Eval) {
   SR registry;
   const auto& manual_clock = static_cast<const ManualClock&>(registry.clock());
@@ -49,9 +41,9 @@ TEST(SubscriptionRegistry, Eval) {
 
   const std::string s{":true,:all"};
 
-  Tags tags1 = from({{"name", "m1"}, {"k1", "v1"}, {"k1", "v2"}});
-  Tags tags2 = from({{"name", "m2"}, {"k1", "v1"}, {"k1", "v2"}});
-  Tags tags3 = from({{"name", "m3"}, {"k1", "v1"}, {"k1", "v2"}});
+  Tags tags1{{"name", "m1"}, {"k1", "v1"}, {"k1", "v2"}};
+  Tags tags2{{"name", "m2"}, {"k1", "v1"}, {"k1", "v2"}};
+  Tags tags3{{"name", "m3"}, {"k1", "v1"}, {"k1", "v2"}};
   TagsValuePair m1{tags1, 1.0};
   TagsValuePair m2{tags2, 2.0};
   TagsValuePair m3{tags3, 3.0};
@@ -65,7 +57,7 @@ TEST(SubscriptionRegistry, MainMetrics) {
   SR registry;
   const auto& manual_clock = static_cast<const ManualClock&>(registry.clock());
   manual_clock.SetWall(42);
-  Tags tags = from({{"k1", "v1"}, {"k1", "v2"}});
+  Tags tags{{"k1", "v1"}, {"k1", "v2"}};
   auto id1 = registry.CreateId("m1", tags);
   auto id3 = registry.CreateId("m3", tags);
 

--- a/test/suscription_registry_test.cc
+++ b/test/suscription_registry_test.cc
@@ -7,6 +7,8 @@
 using atlas::util::Config;
 using atlas::util::ConfigManager;
 using atlas::util::DefaultConfig;
+using atlas::util::intern_str;
+
 using atlas::interpreter::TagsValuePair;
 using atlas::interpreter::TagsValuePairs;
 using atlas::interpreter::Interpreter;
@@ -32,6 +34,14 @@ class SR : public SubscriptionRegistry {
   ManualClock clock_;
 };
 
+static Tags from(std::map<std::string, std::string> ts) {
+  Tags res;
+  for (const auto& kv : ts) {
+    res.add(intern_str(kv.first), intern_str(kv.second));
+  }
+  return res;
+}
+
 TEST(SubscriptionRegistry, Eval) {
   SR registry;
   const auto& manual_clock = static_cast<const ManualClock&>(registry.clock());
@@ -39,9 +49,9 @@ TEST(SubscriptionRegistry, Eval) {
 
   const std::string s{":true,:all"};
 
-  Tags tags1{{"name", "m1"}, {"k1", "v1"}, {"k1", "v2"}};
-  Tags tags2{{"name", "m2"}, {"k1", "v1"}, {"k1", "v2"}};
-  Tags tags3{{"name", "m3"}, {"k1", "v1"}, {"k1", "v2"}};
+  Tags tags1 = from({{"name", "m1"}, {"k1", "v1"}, {"k1", "v2"}});
+  Tags tags2 = from({{"name", "m2"}, {"k1", "v1"}, {"k1", "v2"}});
+  Tags tags3 = from({{"name", "m3"}, {"k1", "v1"}, {"k1", "v2"}});
   TagsValuePair m1{tags1, 1.0};
   TagsValuePair m2{tags2, 2.0};
   TagsValuePair m3{tags3, 3.0};
@@ -55,7 +65,7 @@ TEST(SubscriptionRegistry, MainMetrics) {
   SR registry;
   const auto& manual_clock = static_cast<const ManualClock&>(registry.clock());
   manual_clock.SetWall(42);
-  Tags tags{{"k1", "v1"}, {"k1", "v2"}};
+  Tags tags = from({{"k1", "v1"}, {"k1", "v2"}});
   auto id1 = registry.CreateId("m1", tags);
   auto id3 = registry.CreateId("m3", tags);
 

--- a/test/validation_test.cc
+++ b/test/validation_test.cc
@@ -5,75 +5,66 @@ using atlas::meter::Tags;
 using atlas::meter::validation::IsValid;
 using atlas::util::intern_str;
 
-static Tags from(std::map<std::string, std::string> ts) {
-  Tags res;
-  for (const auto& kv : ts) {
-    res.add(intern_str(kv.first), intern_str(kv.second));
-  }
-  return res;
-}
-
 TEST(Validation, NoName) {
   Tags empty;
   EXPECT_FALSE(IsValid(empty));
 
-  Tags some_random_tags = from({{"k1", "v1"}, {"k2", "v2"}});
+  Tags some_random_tags{{"k1", "v1"}, {"k2", "v2"}};
   EXPECT_FALSE(IsValid(some_random_tags));
 
-  Tags valid = from({{"name", "foobar"}});
+  Tags valid{{"name", "foobar"}};
   EXPECT_TRUE(IsValid(valid));
 }
 
 TEST(Validation, LongName) {
   std::string just_right(255, 'x');
-  Tags just_right_name = from({{"name", just_right}});
+  Tags just_right_name{{"name", just_right.c_str()}};
   EXPECT_TRUE(IsValid(just_right_name));
 
   std::string too_long(256, 'x');
-  Tags too_long_name = from({{"name", too_long}});
+  Tags too_long_name{{"name", too_long.c_str()}};
   EXPECT_FALSE(IsValid(too_long_name));
 }
 
 TEST(Validation, KeyLengths) {
   std::string key_just_right(60, 'k');
-  Tags just_right = from({{"name", "foo"}, {key_just_right, "x"}});
+  Tags just_right{{"name", "foo"}, {key_just_right.c_str(), "x"}};
   EXPECT_TRUE(IsValid(just_right));
 
   std::string key_too_long(61, 'k');
-  Tags too_long = from({{"name", "foo"}, {key_too_long, "v"}});
+  Tags too_long{{"name", "foo"}, {key_too_long.c_str(), "v"}};
   EXPECT_FALSE(IsValid(too_long));
 }
 
 TEST(Validation, EmptyKeyOrValue) {
-  Tags empty_name = from({{"name", ""}, {"k", "v"}, {"k2", "v2"}});
+  Tags empty_name{{"name", ""}, {"k", "v"}, {"k2", "v2"}};
   EXPECT_FALSE(IsValid(empty_name));
 
-  Tags empty_key = from({{"name", "n"}, {"", "v"}, {"k2", "v"}});
+  Tags empty_key{{"name", "n"}, {"", "v"}, {"k2", "v"}};
   EXPECT_FALSE(IsValid(empty_key));
 
-  Tags empty_value = from({{"name", "n"}, {"k1", ""}, {"k2", ""}, {"k3", "v"}});
+  Tags empty_value{{"name", "n"}, {"k1", ""}, {"k2", ""}, {"k3", "v"}};
   EXPECT_FALSE(IsValid(empty_value));
 }
 
 TEST(Validation, InvalidKey) {
-  Tags uses_atlas_ns =
-      from({{"name", "n"}, {"atlas.rules", "true"}, {"atlas.legacy", "epic"}});
+  Tags uses_atlas_ns{
+      {"name", "n"}, {"atlas.rules", "true"}, {"atlas.legacy", "epic"}};
   EXPECT_FALSE(IsValid(uses_atlas_ns));
 
-  Tags uses_nf_ns =
-      from({{"name", "n"}, {"nf.country", "us"}, {"nf.legacy", "epic"}});
+  Tags uses_nf_ns{{"name", "n"}, {"nf.country", "us"}, {"nf.legacy", "epic"}};
   EXPECT_FALSE(IsValid(uses_nf_ns));
 
-  Tags uses_valid_atlas = from({{"atlas.dstype", "counter"}, {"name", "n"}});
+  Tags uses_valid_atlas{{"atlas.dstype", "counter"}, {"name", "n"}};
   EXPECT_TRUE(IsValid(uses_valid_atlas));
 
-  Tags uses_valid_nf = from({{"nf.country", "ar"}, {"name", "n"}});
+  Tags uses_valid_nf{{"nf.country", "ar"}, {"name", "n"}};
   EXPECT_TRUE(IsValid(uses_valid_nf));
 }
 
 TEST(Validation, TooManyUserTags) {
-  Tags tags =
-      from({{"name", "n"}, {"atlas.dstype", "counter"}, {"nf.country", "us"}});
+  Tags tags = {
+      {"name", "n"}, {"atlas.dstype", "counter"}, {"nf.country", "us"}};
 
   for (auto i = 1; i < 20; ++i) {
     tags.add(std::to_string(i).c_str(), "v");

--- a/test/validation_test.cc
+++ b/test/validation_test.cc
@@ -3,72 +3,83 @@
 
 using atlas::meter::Tags;
 using atlas::meter::validation::IsValid;
+using atlas::util::intern_str;
+
+static Tags from(std::map<std::string, std::string> ts) {
+  Tags res;
+  for (const auto& kv : ts) {
+    res.add(intern_str(kv.first), intern_str(kv.second));
+  }
+  return res;
+}
 
 TEST(Validation, NoName) {
   Tags empty;
   EXPECT_FALSE(IsValid(empty));
 
-  Tags some_random_tags{{"k1", "v1"}, {"k2", "v2"}};
+  Tags some_random_tags = from({{"k1", "v1"}, {"k2", "v2"}});
   EXPECT_FALSE(IsValid(some_random_tags));
 
-  Tags valid{{"name", "foobar"}};
+  Tags valid = from({{"name", "foobar"}});
   EXPECT_TRUE(IsValid(valid));
 }
 
 TEST(Validation, LongName) {
   std::string just_right(255, 'x');
-  Tags just_right_name{{"name", just_right}};
+  Tags just_right_name = from({{"name", just_right}});
   EXPECT_TRUE(IsValid(just_right_name));
 
   std::string too_long(256, 'x');
-  Tags too_long_name{{"name", too_long}};
+  Tags too_long_name = from({{"name", too_long}});
   EXPECT_FALSE(IsValid(too_long_name));
 }
 
 TEST(Validation, KeyLengths) {
   std::string key_just_right(60, 'k');
-  Tags just_right{{"name", "foo"}, {key_just_right, "x"}};
+  Tags just_right = from({{"name", "foo"}, {key_just_right, "x"}});
   EXPECT_TRUE(IsValid(just_right));
 
   std::string key_too_long(61, 'k');
-  Tags too_long{{"name", "foo"}, {key_too_long, "v"}};
+  Tags too_long = from({{"name", "foo"}, {key_too_long, "v"}});
   EXPECT_FALSE(IsValid(too_long));
 }
 
 TEST(Validation, EmptyKeyOrValue) {
-  Tags empty_name{{"name", ""}, {"k", "v"}, {"k2", "v2"}};
+  Tags empty_name = from({{"name", ""}, {"k", "v"}, {"k2", "v2"}});
   EXPECT_FALSE(IsValid(empty_name));
 
-  Tags empty_key{{"name", "n"}, {"", "v"}, {"k2", "v"}};
+  Tags empty_key = from({{"name", "n"}, {"", "v"}, {"k2", "v"}});
   EXPECT_FALSE(IsValid(empty_key));
 
-  Tags empty_value{{"name", "n"}, {"k1", ""}, {"k2", ""}, {"k3", "v"}};
+  Tags empty_value = from({{"name", "n"}, {"k1", ""}, {"k2", ""}, {"k3", "v"}});
   EXPECT_FALSE(IsValid(empty_value));
 }
 
 TEST(Validation, InvalidKey) {
-  Tags uses_atlas_ns{
-      {"name", "n"}, {"atlas.rules", "true"}, {"atlas.legacy", "epic"}};
+  Tags uses_atlas_ns =
+      from({{"name", "n"}, {"atlas.rules", "true"}, {"atlas.legacy", "epic"}});
   EXPECT_FALSE(IsValid(uses_atlas_ns));
 
-  Tags uses_nf_ns{{"name", "n"}, {"nf.country", "us"}, {"nf.legacy", "epic"}};
+  Tags uses_nf_ns =
+      from({{"name", "n"}, {"nf.country", "us"}, {"nf.legacy", "epic"}});
   EXPECT_FALSE(IsValid(uses_nf_ns));
 
-  Tags uses_valid_atlas{{"atlas.dstype", "counter"}, {"name", "n"}};
+  Tags uses_valid_atlas = from({{"atlas.dstype", "counter"}, {"name", "n"}});
   EXPECT_TRUE(IsValid(uses_valid_atlas));
 
-  Tags uses_valid_nf{{"nf.country", "ar"}, {"name", "n"}};
+  Tags uses_valid_nf = from({{"nf.country", "ar"}, {"name", "n"}});
   EXPECT_TRUE(IsValid(uses_valid_nf));
 }
 
 TEST(Validation, TooManyUserTags) {
-  Tags tags{{"name", "n"}, {"atlas.dstype", "counter"}, {"nf.country", "us"}};
+  Tags tags =
+      from({{"name", "n"}, {"atlas.dstype", "counter"}, {"nf.country", "us"}});
 
   for (auto i = 1; i < 20; ++i) {
-    tags[std::to_string(i)] = "v";
+    tags.add(std::to_string(i).c_str(), "v");
   }
   EXPECT_TRUE(IsValid(tags));
 
-  tags["extra"] = "v";
+  tags.add("extra", "v");
   EXPECT_FALSE(IsValid(tags));
 }

--- a/util/config.cc
+++ b/util/config.cc
@@ -17,7 +17,7 @@ Config::Config(const std::string& evaluate_endpoint,
                int read_timeout, int batch_size, bool force_start,
                bool enable_main, bool enable_subscriptions, bool dump_metrics,
                bool dump_subscriptions, int log_verbosity,
-               std::map<std::string, std::string> common_tags) noexcept
+               meter::Tags common_tags) noexcept
     : evaluate_endpoint_(ExpandEnvVars(evaluate_endpoint)),
       subscriptions_endpoint_(ExpandEnvVars(subscriptions_endpoint)),
       publish_endpoint_(ExpandEnvVars(publish_endpoint)),

--- a/util/config.h
+++ b/util/config.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include "../meter/id.h"
 
 namespace atlas {
 namespace util {
@@ -21,7 +22,7 @@ class Config {
          int connect_timeout, int read_timeout, int batch_size,
          bool force_start, bool enable_main, bool enable_subscriptions,
          bool dump_metrics, bool dump_subscriptions, int log_verbosity,
-         std::map<std::string, std::string> common_tags) noexcept;
+         meter::Tags common_tags) noexcept;
 
   std::string EvalEndpoint() const noexcept { return evaluate_endpoint_; }
   std::string SubsEndpoint() const noexcept { return subscriptions_endpoint_; }
@@ -45,12 +46,9 @@ class Config {
     return publish_config_;
   }
   int LogVerbosity() const noexcept { return log_verbosity_; }
-  std::map<std::string, std::string> CommonTags() const noexcept {
-    return common_tags_;
-  }
-  void AddCommonTags(
-      const std::map<std::string, std::string>& extra_tags) noexcept {
-    common_tags_.insert(extra_tags.begin(), extra_tags.end());
+  meter::Tags CommonTags() const noexcept { return common_tags_; }
+  void AddCommonTags(const meter::Tags& extra_tags) noexcept {
+    common_tags_.add_all(extra_tags);
   }
 
  private:
@@ -71,7 +69,7 @@ class Config {
   bool dump_metrics_;
   bool dump_subscriptions_;
   int log_verbosity_;
-  std::map<std::string, std::string> common_tags_;
+  meter::Tags common_tags_;
 };
 
 std::string ConfigToString(const Config& config) noexcept;

--- a/util/config_manager.cc
+++ b/util/config_manager.cc
@@ -46,12 +46,12 @@ static std::vector<std::string> vector_from(const rapidjson::Value& array) {
 static inline void put_if_nonempty(meter::Tags* tags, const char* key,
                                    std::string&& val) {
   if (!val.empty()) {
-    tags->insert(std::make_pair(std::string{key}, val));
+    tags->add(key, val.c_str());
   }
 }
 
-static std::map<std::string, std::string> get_default_common_tags() {
-  std::map<std::string, std::string> common_tags_;
+static meter::Tags get_default_common_tags() {
+  meter::Tags common_tags_;
   put_if_nonempty(&common_tags_, "nf.node", env::instance_id());
   put_if_nonempty(&common_tags_, "nf.cluster", env::cluster());
   put_if_nonempty(&common_tags_, "nf.app", env::app());
@@ -237,7 +237,7 @@ void ConfigManager::refresh_configs() noexcept {
 }
 
 void ConfigManager::AddCommonTag(const char* key, const char* value) noexcept {
-  extra_tags_.emplace(std::make_pair(std::string(key), std::string(value)));
+  extra_tags_.add(key, value);
 }
 
 }  // namespace util

--- a/util/config_manager.h
+++ b/util/config_manager.h
@@ -29,7 +29,7 @@ class ConfigManager {
   mutable std::mutex config_mutex;
   std::shared_ptr<Config> current_config_;
   std::atomic<bool> should_run_{false};
-  std::map<std::string, std::string> extra_tags_;
+  meter::Tags extra_tags_;
 
   void refresher() noexcept;
   void refresh_configs() noexcept;

--- a/util/dump.h
+++ b/util/dump.h
@@ -1,12 +1,14 @@
 #pragma once
 
+#include "../meter/id.h"
 #include <map>
 #include <string>
 #include <vector>
 
 template <typename OStream>
-inline OStream& dump_tags(OStream& os,
-                          const std::map<std::string, std::string>& tags) {
+inline OStream& dump_tags(OStream& os, const atlas::meter::Tags& tags) {
+  using atlas::util::to_string;
+
   bool first = true;
   os << '[';
   for (const auto& tag : tags) {
@@ -15,7 +17,7 @@ inline OStream& dump_tags(OStream& os,
     } else {
       os << ", ";
     }
-    os << tag.first << "->" << tag.second;
+    os << to_string(tag.first) << "->" << to_string(tag.second);
   }
   os << ']';
   return os;

--- a/util/dump.h
+++ b/util/dump.h
@@ -7,8 +7,6 @@
 
 template <typename OStream>
 inline OStream& dump_tags(OStream& os, const atlas::meter::Tags& tags) {
-  using atlas::util::to_string;
-
   bool first = true;
   os << '[';
   for (const auto& tag : tags) {
@@ -17,7 +15,7 @@ inline OStream& dump_tags(OStream& os, const atlas::meter::Tags& tags) {
     } else {
       os << ", ";
     }
-    os << to_string(tag.first) << "->" << to_string(tag.second);
+    os << tag.first.get() << "->" << tag.second.get();
   }
   os << ']';
   return os;

--- a/util/intern.cc
+++ b/util/intern.cc
@@ -1,0 +1,71 @@
+#include "intern.h"
+#include "xxhash.h"
+#include <cassert>
+#include <cstring>
+#include <mutex>
+#include <unordered_map>
+
+namespace atlas {
+namespace util {
+
+struct Hasher {
+  size_t operator()(const char* str) const {
+    return XXH64(str, strlen(str), 42);
+  }
+};
+
+struct Comparer {
+  bool operator()(const char* s1, const char* s2) const {
+    return std::strcmp(s1, s2) == 0;
+  }
+};
+
+class StringPool {
+ public:
+  StringPool() noexcept {}
+  ~StringPool() noexcept = default;
+  StringPool(const StringPool& pool) = delete;
+  StringPool& operator=(const StringPool& pool) = delete;
+
+  const StrRef& intern(const char* string) {
+    std::lock_guard<std::mutex> guard(mutex);
+    auto it = table.find(string);
+    if (it != table.end()) {
+      return it->second;
+    }
+    const auto* copy = strdup(string);
+    StrRef ref;
+    ref.data = copy;
+    table.insert(std::make_pair(copy, ref));
+    return table.at(copy);
+  }
+
+  const char* to_string(const StrRef& ref) { return ref.data; }
+
+ private:
+  std::unordered_map<const char*, StrRef, Hasher, Comparer> table;
+
+  std::mutex mutex;
+};
+
+static StringPool the_pool;
+
+const StrRef& intern_str(const char* string) {
+  const auto& r = the_pool.intern(string);
+#ifdef DEBUG
+  if (strcmp(string, to_string(r)) != 0) {
+    printf("Unable to intern %s = %s -> %s\n", string, r.data, to_string(r));
+    abort();
+  }
+#endif
+  return r;
+}
+
+const StrRef& intern_str(const std::string& string) {
+  return intern_str(string.c_str());
+}
+
+const char* to_string(const StrRef& ref) { return the_pool.to_string(ref); }
+
+}  // namespace util
+}  // namespace atlas

--- a/util/intern.cc
+++ b/util/intern.cc
@@ -40,8 +40,6 @@ class StringPool {
     return table.at(copy);
   }
 
-  const char* to_string(const StrRef& ref) { return ref.data; }
-
  private:
   std::unordered_map<const char*, StrRef, Hasher, Comparer> table;
 
@@ -53,8 +51,8 @@ static StringPool the_pool;
 const StrRef& intern_str(const char* string) {
   const auto& r = the_pool.intern(string);
 #ifdef DEBUG
-  if (strcmp(string, to_string(r)) != 0) {
-    printf("Unable to intern %s = %s -> %s\n", string, r.data, to_string(r));
+  if (strcmp(string, r.get()) != 0) {
+    printf("Unable to intern %s = %s -> %s\n", string, r.data, r.get());
     abort();
   }
 #endif
@@ -64,8 +62,6 @@ const StrRef& intern_str(const char* string) {
 const StrRef& intern_str(const std::string& string) {
   return intern_str(string.c_str());
 }
-
-const char* to_string(const StrRef& ref) { return the_pool.to_string(ref); }
 
 }  // namespace util
 }  // namespace atlas

--- a/util/intern.h
+++ b/util/intern.h
@@ -6,16 +6,22 @@
 namespace atlas {
 namespace util {
 
+class StringPool;
+
 class StrRef {
  public:
   StrRef() = default;
   bool operator==(const StrRef& rhs) const { return data == rhs.data; }
+  const char* get() const { return data; }
+
+ private:
   const char* data = nullptr;
+  friend std::hash<StrRef>;
+  friend StringPool;
 };
 
 const StrRef& intern_str(const char* string);
 const StrRef& intern_str(const std::string& string);
-const char* to_string(const StrRef& ref);
 }
 }
 

--- a/util/intern.h
+++ b/util/intern.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace atlas {
+namespace util {
+
+class StrRef {
+ public:
+  StrRef() = default;
+  bool operator==(const StrRef& rhs) const { return data == rhs.data; }
+  const char* data = nullptr;
+};
+
+const StrRef& intern_str(const char* string);
+const StrRef& intern_str(const std::string& string);
+const char* to_string(const StrRef& ref);
+}
+}
+
+namespace std {
+template <>
+struct hash<atlas::util::StrRef> {
+  size_t operator()(const atlas::util::StrRef& ref) const {
+    return reinterpret_cast<size_t>(ref.data);
+  }
+};
+}

--- a/util/strings.cc
+++ b/util/strings.cc
@@ -76,9 +76,10 @@ std::string ExpandEnvVars(const std::string& raw) noexcept {
   return ExpandVars(raw, expander);
 }
 
-static std::string ToValidTable(const std::array<bool, 128>& table,
-                                const std::string& atlas_str) noexcept {
+static StrRef ToValidTable(const std::array<bool, 128>& table,
+                           StrRef atlas_str_ref) noexcept {
   std::string ret;
+  std::string atlas_str = to_string(atlas_str_ref);
   ret.resize(atlas_str.size());
   const auto n = atlas_str.length();
   for (size_t i = 0; i < n; ++i) {
@@ -86,11 +87,11 @@ static std::string ToValidTable(const std::array<bool, 128>& table,
     auto valid = (static_cast<size_t>(ch) >= table.size()) ? false : table[ch];
     ret[i] = valid ? ch : '_';
   }
-  return ret;
+  return intern_str(ret);
 }
 
-std::string ToValidCharset(const std::string& atlas_str) noexcept {
-  return ToValidTable(kCharsAllowed, atlas_str);
+StrRef ToValidCharset(StrRef atlas_str_ref) noexcept {
+  return ToValidTable(kCharsAllowed, atlas_str_ref);
 }
 
 std::string join_path(const std::string& dir, const char* file_name) noexcept {
@@ -107,9 +108,11 @@ std::string join_path(const std::string& dir, const char* file_name) noexcept {
   return os.str();
 }
 
-std::string EncodeValueForKey(const std::string& value,
-                              const std::string& key) noexcept {
-  auto isGroup = key == "nf.asg" || key == "nf.cluster";
+auto kAsgRef = intern_str("nf.asg");
+auto kClusterRef = intern_str("nf.cluster");
+
+StrRef EncodeValueForKey(StrRef value, StrRef key) noexcept {
+  auto isGroup = kAsgRef == key || kClusterRef == key;
   const auto& table = isGroup ? kGroupCharsAllowed : kCharsAllowed;
   return ToValidTable(table, value);
 }

--- a/util/strings.cc
+++ b/util/strings.cc
@@ -79,7 +79,7 @@ std::string ExpandEnvVars(const std::string& raw) noexcept {
 static StrRef ToValidTable(const std::array<bool, 128>& table,
                            StrRef atlas_str_ref) noexcept {
   std::string ret;
-  std::string atlas_str = to_string(atlas_str_ref);
+  std::string atlas_str = atlas_str_ref.get();
   ret.resize(atlas_str.size());
   const auto n = atlas_str.length();
   for (size_t i = 0; i < n; ++i) {

--- a/util/strings.h
+++ b/util/strings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "intern.h"
 #include <algorithm>
 #include <cctype>
 #include <functional>
@@ -35,13 +36,12 @@ std::string ExpandEnvVars(const std::string& raw) noexcept;
 /// get the sanitized string representation of atlas_str
 /// letters, numbers, dots, and underscores are allowed, otherwise we convert it
 /// to _
-std::string ToValidCharset(const std::string& atlas_str) noexcept;
+StrRef ToValidCharset(StrRef atlas_str_ref) noexcept;
 
 /// convert value to a representation atlas would allow
 /// some keys have a more relaxed restriction, therefore this
 /// function needs to know for which key we need to encode
-std::string EncodeValueForKey(const std::string& value,
-                              const std::string& key) noexcept;
+StrRef EncodeValueForKey(StrRef value, StrRef key) noexcept;
 
 std::string join_path(const std::string& dir, const char* file_name) noexcept;
 

--- a/util/xxhash.c
+++ b/util/xxhash.c
@@ -1,0 +1,894 @@
+/*
+*  xxHash - Fast Hash algorithm
+*  Copyright (C) 2012-2016, Yann Collet
+*
+*  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are
+*  met:
+*
+*  * Redistributions of source code must retain the above copyright
+*  notice, this list of conditions and the following disclaimer.
+*  * Redistributions in binary form must reproduce the above
+*  copyright notice, this list of conditions and the following disclaimer
+*  in the documentation and/or other materials provided with the
+*  distribution.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*  You can contact the author at :
+*  - xxHash homepage: http://www.xxhash.com
+*  - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+
+/* *************************************
+*  Tuning parameters
+***************************************/
+/*!XXH_FORCE_MEMORY_ACCESS :
+ * By default, access to unaligned memory is controlled by `memcpy()`, which is safe and portable.
+ * Unfortunately, on some target/compiler combinations, the generated assembly is sub-optimal.
+ * The below switch allow to select different access method for improved performance.
+ * Method 0 (default) : use `memcpy()`. Safe and portable.
+ * Method 1 : `__packed` statement. It depends on compiler extension (ie, not portable).
+ *            This method is safe if your compiler supports it, and *generally* as fast or faster than `memcpy`.
+ * Method 2 : direct access. This method doesn't depend on compiler but violate C standard.
+ *            It can generate buggy code on targets which do not support unaligned memory accesses.
+ *            But in some circumstances, it's the only known way to get the most performance (ie GCC + ARMv6)
+ * See http://stackoverflow.com/a/32095106/646947 for details.
+ * Prefer these methods in priority order (0 > 1 > 2)
+ */
+#ifndef XXH_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
+#  if defined(__GNUC__) && ( defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) )
+#    define XXH_FORCE_MEMORY_ACCESS 2
+#  elif defined(__INTEL_COMPILER) || \
+  (defined(__GNUC__) && ( defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7S__) ))
+#    define XXH_FORCE_MEMORY_ACCESS 1
+#  endif
+#endif
+
+/*!XXH_ACCEPT_NULL_INPUT_POINTER :
+ * If the input pointer is a null pointer, xxHash default behavior is to trigger a memory access error, since it is a bad pointer.
+ * When this option is enabled, xxHash output for null input pointers will be the same as a null-length input.
+ * By default, this option is disabled. To enable it, uncomment below define :
+ */
+/* #define XXH_ACCEPT_NULL_INPUT_POINTER 1 */
+
+/*!XXH_FORCE_NATIVE_FORMAT :
+ * By default, xxHash library provides endian-independent Hash values, based on little-endian convention.
+ * Results are therefore identical for little-endian and big-endian CPU.
+ * This comes at a performance cost for big-endian CPU, since some swapping is required to emulate little-endian format.
+ * Should endian-independence be of no importance for your application, you may set the #define below to 1,
+ * to improve speed for Big-endian CPU.
+ * This option has no impact on Little_Endian CPU.
+ */
+#ifndef XXH_FORCE_NATIVE_FORMAT   /* can be defined externally */
+#  define XXH_FORCE_NATIVE_FORMAT 0
+#endif
+
+/*!XXH_FORCE_ALIGN_CHECK :
+ * This is a minor performance trick, only useful with lots of very small keys.
+ * It means : check for aligned/unaligned input.
+ * The check costs one initial branch per hash;
+ * set it to 0 when the input is guaranteed to be aligned,
+ * or when alignment doesn't matter for performance.
+ */
+#ifndef XXH_FORCE_ALIGN_CHECK /* can be defined externally */
+#  if defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64)
+#    define XXH_FORCE_ALIGN_CHECK 0
+#  else
+#    define XXH_FORCE_ALIGN_CHECK 1
+#  endif
+#endif
+
+
+/* *************************************
+*  Includes & Memory related functions
+***************************************/
+/*! Modify the local functions below should you wish to use some other memory routines
+*   for malloc(), free() */
+#include <stdlib.h>
+static void* XXH_malloc(size_t s) { return malloc(s); }
+static void  XXH_free  (void* p)  { free(p); }
+/*! and for memcpy() */
+#include <string.h>
+static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcpy(dest,src,size); }
+
+#define XXH_STATIC_LINKING_ONLY
+#include "xxhash.h"
+
+
+/* *************************************
+*  Compiler Specific Options
+***************************************/
+#ifdef _MSC_VER    /* Visual Studio */
+#  pragma warning(disable : 4127)      /* disable: C4127: conditional expression is constant */
+#  define FORCE_INLINE static __forceinline
+#else
+#  if defined (__cplusplus) || defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
+#    ifdef __GNUC__
+#      define FORCE_INLINE static inline __attribute__((always_inline))
+#    else
+#      define FORCE_INLINE static inline
+#    endif
+#  else
+#    define FORCE_INLINE static
+#  endif /* __STDC_VERSION__ */
+#endif
+
+
+/* *************************************
+*  Basic Types
+***************************************/
+#ifndef MEM_MODULE
+# if !defined (__VMS) && (defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#   include <stdint.h>
+    typedef uint8_t  BYTE;
+    typedef uint16_t U16;
+    typedef uint32_t U32;
+# else
+    typedef unsigned char      BYTE;
+    typedef unsigned short     U16;
+    typedef unsigned int       U32;
+# endif
+#endif
+
+#if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==2))
+
+/* Force direct memory access. Only works on CPU which support unaligned memory access in hardware */
+static U32 XXH_read32(const void* memPtr) { return *(const U32*) memPtr; }
+
+#elif (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==1))
+
+/* __pack instructions are safer, but compiler specific, hence potentially problematic for some compilers */
+/* currently only defined for gcc and icc */
+typedef union { U32 u32; } __attribute__((packed)) unalign;
+static U32 XXH_read32(const void* ptr) { return ((const unalign*)ptr)->u32; }
+
+#else
+
+/* portable and safe solution. Generally efficient.
+ * see : http://stackoverflow.com/a/32095106/646947
+ */
+static U32 XXH_read32(const void* memPtr)
+{
+    U32 val;
+    memcpy(&val, memPtr, sizeof(val));
+    return val;
+}
+
+#endif   /* XXH_FORCE_DIRECT_MEMORY_ACCESS */
+
+
+/* ****************************************
+*  Compiler-specific Functions and Macros
+******************************************/
+#define XXH_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+
+/* Note : although _rotl exists for minGW (GCC under windows), performance seems poor */
+#if defined(_MSC_VER)
+#  define XXH_rotl32(x,r) _rotl(x,r)
+#  define XXH_rotl64(x,r) _rotl64(x,r)
+#else
+#  define XXH_rotl32(x,r) ((x << r) | (x >> (32 - r)))
+#  define XXH_rotl64(x,r) ((x << r) | (x >> (64 - r)))
+#endif
+
+#if defined(_MSC_VER)     /* Visual Studio */
+#  define XXH_swap32 _byteswap_ulong
+#elif XXH_GCC_VERSION >= 403
+#  define XXH_swap32 __builtin_bswap32
+#else
+static U32 XXH_swap32 (U32 x)
+{
+    return  ((x << 24) & 0xff000000 ) |
+            ((x <<  8) & 0x00ff0000 ) |
+            ((x >>  8) & 0x0000ff00 ) |
+            ((x >> 24) & 0x000000ff );
+}
+#endif
+
+
+/* *************************************
+*  Architecture Macros
+***************************************/
+typedef enum { XXH_bigEndian=0, XXH_littleEndian=1 } XXH_endianess;
+
+/* XXH_CPU_LITTLE_ENDIAN can be defined externally, for example on the compiler command line */
+#ifndef XXH_CPU_LITTLE_ENDIAN
+    static const int g_one = 1;
+#   define XXH_CPU_LITTLE_ENDIAN   (*(const char*)(&g_one))
+#endif
+
+
+/* ***************************
+*  Memory reads
+*****************************/
+typedef enum { XXH_aligned, XXH_unaligned } XXH_alignment;
+
+FORCE_INLINE U32 XXH_readLE32_align(const void* ptr, XXH_endianess endian, XXH_alignment align)
+{
+    if (align==XXH_unaligned)
+        return endian==XXH_littleEndian ? XXH_read32(ptr) : XXH_swap32(XXH_read32(ptr));
+    else
+        return endian==XXH_littleEndian ? *(const U32*)ptr : XXH_swap32(*(const U32*)ptr);
+}
+
+FORCE_INLINE U32 XXH_readLE32(const void* ptr, XXH_endianess endian)
+{
+    return XXH_readLE32_align(ptr, endian, XXH_unaligned);
+}
+
+static U32 XXH_readBE32(const void* ptr)
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_swap32(XXH_read32(ptr)) : XXH_read32(ptr);
+}
+
+
+/* *************************************
+*  Macros
+***************************************/
+#define XXH_STATIC_ASSERT(c)   { enum { XXH_static_assert = 1/(int)(!!(c)) }; }    /* use only *after* variable declarations */
+XXH_PUBLIC_API unsigned XXH_versionNumber (void) { return XXH_VERSION_NUMBER; }
+
+
+/* *******************************************************************
+*  32-bits hash functions
+*********************************************************************/
+static const U32 PRIME32_1 = 2654435761U;
+static const U32 PRIME32_2 = 2246822519U;
+static const U32 PRIME32_3 = 3266489917U;
+static const U32 PRIME32_4 =  668265263U;
+static const U32 PRIME32_5 =  374761393U;
+
+static U32 XXH32_round(U32 seed, U32 input)
+{
+    seed += input * PRIME32_2;
+    seed  = XXH_rotl32(seed, 13);
+    seed *= PRIME32_1;
+    return seed;
+}
+
+FORCE_INLINE U32 XXH32_endian_align(const void* input, size_t len, U32 seed, XXH_endianess endian, XXH_alignment align)
+{
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* bEnd = p + len;
+    U32 h32;
+#define XXH_get32bits(p) XXH_readLE32_align(p, endian, align)
+
+#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
+    if (p==NULL) {
+        len=0;
+        bEnd=p=(const BYTE*)(size_t)16;
+    }
+#endif
+
+    if (len>=16) {
+        const BYTE* const limit = bEnd - 16;
+        U32 v1 = seed + PRIME32_1 + PRIME32_2;
+        U32 v2 = seed + PRIME32_2;
+        U32 v3 = seed + 0;
+        U32 v4 = seed - PRIME32_1;
+
+        do {
+            v1 = XXH32_round(v1, XXH_get32bits(p)); p+=4;
+            v2 = XXH32_round(v2, XXH_get32bits(p)); p+=4;
+            v3 = XXH32_round(v3, XXH_get32bits(p)); p+=4;
+            v4 = XXH32_round(v4, XXH_get32bits(p)); p+=4;
+        } while (p<=limit);
+
+        h32 = XXH_rotl32(v1, 1) + XXH_rotl32(v2, 7) + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
+    } else {
+        h32  = seed + PRIME32_5;
+    }
+
+    h32 += (U32) len;
+
+    while (p+4<=bEnd) {
+        h32 += XXH_get32bits(p) * PRIME32_3;
+        h32  = XXH_rotl32(h32, 17) * PRIME32_4 ;
+        p+=4;
+    }
+
+    while (p<bEnd) {
+        h32 += (*p) * PRIME32_5;
+        h32 = XXH_rotl32(h32, 11) * PRIME32_1 ;
+        p++;
+    }
+
+    h32 ^= h32 >> 15;
+    h32 *= PRIME32_2;
+    h32 ^= h32 >> 13;
+    h32 *= PRIME32_3;
+    h32 ^= h32 >> 16;
+
+    return h32;
+}
+
+
+XXH_PUBLIC_API unsigned int XXH32 (const void* input, size_t len, unsigned int seed)
+{
+#if 0
+    /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
+    XXH32_state_t state;
+    XXH32_reset(&state, seed);
+    XXH32_update(&state, input, len);
+    return XXH32_digest(&state);
+#else
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if (XXH_FORCE_ALIGN_CHECK) {
+        if ((((size_t)input) & 3) == 0) {   /* Input is 4-bytes aligned, leverage the speed benefit */
+            if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+                return XXH32_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned);
+            else
+                return XXH32_endian_align(input, len, seed, XXH_bigEndian, XXH_aligned);
+    }   }
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH32_endian_align(input, len, seed, XXH_littleEndian, XXH_unaligned);
+    else
+        return XXH32_endian_align(input, len, seed, XXH_bigEndian, XXH_unaligned);
+#endif
+}
+
+
+
+/*======   Hash streaming   ======*/
+
+XXH_PUBLIC_API XXH32_state_t* XXH32_createState(void)
+{
+    return (XXH32_state_t*)XXH_malloc(sizeof(XXH32_state_t));
+}
+XXH_PUBLIC_API XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr)
+{
+    XXH_free(statePtr);
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* dstState, const XXH32_state_t* srcState)
+{
+    memcpy(dstState, srcState, sizeof(*dstState));
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, unsigned int seed)
+{
+    XXH32_state_t state;   /* using a local state to memcpy() in order to avoid strict-aliasing warnings */
+    memset(&state, 0, sizeof(state)-4);   /* do not write into reserved, for future removal */
+    state.v1 = seed + PRIME32_1 + PRIME32_2;
+    state.v2 = seed + PRIME32_2;
+    state.v3 = seed + 0;
+    state.v4 = seed - PRIME32_1;
+    memcpy(statePtr, &state, sizeof(state));
+    return XXH_OK;
+}
+
+
+FORCE_INLINE XXH_errorcode XXH32_update_endian (XXH32_state_t* state, const void* input, size_t len, XXH_endianess endian)
+{
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* const bEnd = p + len;
+
+    if (input==NULL)
+#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
+        return XXH_OK;
+#else
+        return XXH_ERROR;
+#endif
+
+    state->total_len_32 += (unsigned)len;
+    state->large_len |= (len>=16) | (state->total_len_32>=16);
+
+    if (state->memsize + len < 16)  {   /* fill in tmp buffer */
+        XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, len);
+        state->memsize += (unsigned)len;
+        return XXH_OK;
+    }
+
+    if (state->memsize) {   /* some data left from previous update */
+        XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, 16-state->memsize);
+        {   const U32* p32 = state->mem32;
+            state->v1 = XXH32_round(state->v1, XXH_readLE32(p32, endian)); p32++;
+            state->v2 = XXH32_round(state->v2, XXH_readLE32(p32, endian)); p32++;
+            state->v3 = XXH32_round(state->v3, XXH_readLE32(p32, endian)); p32++;
+            state->v4 = XXH32_round(state->v4, XXH_readLE32(p32, endian));
+        }
+        p += 16-state->memsize;
+        state->memsize = 0;
+    }
+
+    if (p <= bEnd-16) {
+        const BYTE* const limit = bEnd - 16;
+        U32 v1 = state->v1;
+        U32 v2 = state->v2;
+        U32 v3 = state->v3;
+        U32 v4 = state->v4;
+
+        do {
+            v1 = XXH32_round(v1, XXH_readLE32(p, endian)); p+=4;
+            v2 = XXH32_round(v2, XXH_readLE32(p, endian)); p+=4;
+            v3 = XXH32_round(v3, XXH_readLE32(p, endian)); p+=4;
+            v4 = XXH32_round(v4, XXH_readLE32(p, endian)); p+=4;
+        } while (p<=limit);
+
+        state->v1 = v1;
+        state->v2 = v2;
+        state->v3 = v3;
+        state->v4 = v4;
+    }
+
+    if (p < bEnd) {
+        XXH_memcpy(state->mem32, p, (size_t)(bEnd-p));
+        state->memsize = (unsigned)(bEnd-p);
+    }
+
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH32_update (XXH32_state_t* state_in, const void* input, size_t len)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH32_update_endian(state_in, input, len, XXH_littleEndian);
+    else
+        return XXH32_update_endian(state_in, input, len, XXH_bigEndian);
+}
+
+
+
+FORCE_INLINE U32 XXH32_digest_endian (const XXH32_state_t* state, XXH_endianess endian)
+{
+    const BYTE * p = (const BYTE*)state->mem32;
+    const BYTE* const bEnd = (const BYTE*)(state->mem32) + state->memsize;
+    U32 h32;
+
+    if (state->large_len) {
+        h32 = XXH_rotl32(state->v1, 1) + XXH_rotl32(state->v2, 7) + XXH_rotl32(state->v3, 12) + XXH_rotl32(state->v4, 18);
+    } else {
+        h32 = state->v3 /* == seed */ + PRIME32_5;
+    }
+
+    h32 += state->total_len_32;
+
+    while (p+4<=bEnd) {
+        h32 += XXH_readLE32(p, endian) * PRIME32_3;
+        h32  = XXH_rotl32(h32, 17) * PRIME32_4;
+        p+=4;
+    }
+
+    while (p<bEnd) {
+        h32 += (*p) * PRIME32_5;
+        h32  = XXH_rotl32(h32, 11) * PRIME32_1;
+        p++;
+    }
+
+    h32 ^= h32 >> 15;
+    h32 *= PRIME32_2;
+    h32 ^= h32 >> 13;
+    h32 *= PRIME32_3;
+    h32 ^= h32 >> 16;
+
+    return h32;
+}
+
+
+XXH_PUBLIC_API unsigned int XXH32_digest (const XXH32_state_t* state_in)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH32_digest_endian(state_in, XXH_littleEndian);
+    else
+        return XXH32_digest_endian(state_in, XXH_bigEndian);
+}
+
+
+/*======   Canonical representation   ======*/
+
+/*! Default XXH result types are basic unsigned 32 and 64 bits.
+*   The canonical representation follows human-readable write convention, aka big-endian (large digits first).
+*   These functions allow transformation of hash result into and from its canonical format.
+*   This way, hash values can be written into a file or buffer, and remain comparable across different systems and programs.
+*/
+
+XXH_PUBLIC_API void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH32_canonical_t) == sizeof(XXH32_hash_t));
+    if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap32(hash);
+    memcpy(dst, &hash, sizeof(*dst));
+}
+
+XXH_PUBLIC_API XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src)
+{
+    return XXH_readBE32(src);
+}
+
+
+#ifndef XXH_NO_LONG_LONG
+
+/* *******************************************************************
+*  64-bits hash functions
+*********************************************************************/
+
+/*======   Memory access   ======*/
+
+#ifndef MEM_MODULE
+# define MEM_MODULE
+# if !defined (__VMS) && (defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#   include <stdint.h>
+    typedef uint64_t U64;
+# else
+    typedef unsigned long long U64;   /* if your compiler doesn't support unsigned long long, replace by another 64-bit type here. Note that xxhash.h will also need to be updated. */
+# endif
+#endif
+
+
+#if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==2))
+
+/* Force direct memory access. Only works on CPU which support unaligned memory access in hardware */
+static U64 XXH_read64(const void* memPtr) { return *(const U64*) memPtr; }
+
+#elif (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==1))
+
+/* __pack instructions are safer, but compiler specific, hence potentially problematic for some compilers */
+/* currently only defined for gcc and icc */
+typedef union { U32 u32; U64 u64; } __attribute__((packed)) unalign64;
+static U64 XXH_read64(const void* ptr) { return ((const unalign64*)ptr)->u64; }
+
+#else
+
+/* portable and safe solution. Generally efficient.
+ * see : http://stackoverflow.com/a/32095106/646947
+ */
+
+static U64 XXH_read64(const void* memPtr)
+{
+    U64 val;
+    memcpy(&val, memPtr, sizeof(val));
+    return val;
+}
+
+#endif   /* XXH_FORCE_DIRECT_MEMORY_ACCESS */
+
+#if defined(_MSC_VER)     /* Visual Studio */
+#  define XXH_swap64 _byteswap_uint64
+#elif XXH_GCC_VERSION >= 403
+#  define XXH_swap64 __builtin_bswap64
+#else
+static U64 XXH_swap64 (U64 x)
+{
+    return  ((x << 56) & 0xff00000000000000ULL) |
+            ((x << 40) & 0x00ff000000000000ULL) |
+            ((x << 24) & 0x0000ff0000000000ULL) |
+            ((x << 8)  & 0x000000ff00000000ULL) |
+            ((x >> 8)  & 0x00000000ff000000ULL) |
+            ((x >> 24) & 0x0000000000ff0000ULL) |
+            ((x >> 40) & 0x000000000000ff00ULL) |
+            ((x >> 56) & 0x00000000000000ffULL);
+}
+#endif
+
+FORCE_INLINE U64 XXH_readLE64_align(const void* ptr, XXH_endianess endian, XXH_alignment align)
+{
+    if (align==XXH_unaligned)
+        return endian==XXH_littleEndian ? XXH_read64(ptr) : XXH_swap64(XXH_read64(ptr));
+    else
+        return endian==XXH_littleEndian ? *(const U64*)ptr : XXH_swap64(*(const U64*)ptr);
+}
+
+FORCE_INLINE U64 XXH_readLE64(const void* ptr, XXH_endianess endian)
+{
+    return XXH_readLE64_align(ptr, endian, XXH_unaligned);
+}
+
+static U64 XXH_readBE64(const void* ptr)
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_swap64(XXH_read64(ptr)) : XXH_read64(ptr);
+}
+
+
+/*======   xxh64   ======*/
+
+static const U64 PRIME64_1 = 11400714785074694791ULL;
+static const U64 PRIME64_2 = 14029467366897019727ULL;
+static const U64 PRIME64_3 =  1609587929392839161ULL;
+static const U64 PRIME64_4 =  9650029242287828579ULL;
+static const U64 PRIME64_5 =  2870177450012600261ULL;
+
+static U64 XXH64_round(U64 acc, U64 input)
+{
+    acc += input * PRIME64_2;
+    acc  = XXH_rotl64(acc, 31);
+    acc *= PRIME64_1;
+    return acc;
+}
+
+static U64 XXH64_mergeRound(U64 acc, U64 val)
+{
+    val  = XXH64_round(0, val);
+    acc ^= val;
+    acc  = acc * PRIME64_1 + PRIME64_4;
+    return acc;
+}
+
+FORCE_INLINE U64 XXH64_endian_align(const void* input, size_t len, U64 seed, XXH_endianess endian, XXH_alignment align)
+{
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* bEnd = p + len;
+    U64 h64;
+#define XXH_get64bits(p) XXH_readLE64_align(p, endian, align)
+
+#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
+    if (p==NULL) {
+        len=0;
+        bEnd=p=(const BYTE*)(size_t)32;
+    }
+#endif
+
+    if (len>=32) {
+        const BYTE* const limit = bEnd - 32;
+        U64 v1 = seed + PRIME64_1 + PRIME64_2;
+        U64 v2 = seed + PRIME64_2;
+        U64 v3 = seed + 0;
+        U64 v4 = seed - PRIME64_1;
+
+        do {
+            v1 = XXH64_round(v1, XXH_get64bits(p)); p+=8;
+            v2 = XXH64_round(v2, XXH_get64bits(p)); p+=8;
+            v3 = XXH64_round(v3, XXH_get64bits(p)); p+=8;
+            v4 = XXH64_round(v4, XXH_get64bits(p)); p+=8;
+        } while (p<=limit);
+
+        h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
+        h64 = XXH64_mergeRound(h64, v1);
+        h64 = XXH64_mergeRound(h64, v2);
+        h64 = XXH64_mergeRound(h64, v3);
+        h64 = XXH64_mergeRound(h64, v4);
+
+    } else {
+        h64  = seed + PRIME64_5;
+    }
+
+    h64 += (U64) len;
+
+    while (p+8<=bEnd) {
+        U64 const k1 = XXH64_round(0, XXH_get64bits(p));
+        h64 ^= k1;
+        h64  = XXH_rotl64(h64,27) * PRIME64_1 + PRIME64_4;
+        p+=8;
+    }
+
+    if (p+4<=bEnd) {
+        h64 ^= (U64)(XXH_get32bits(p)) * PRIME64_1;
+        h64 = XXH_rotl64(h64, 23) * PRIME64_2 + PRIME64_3;
+        p+=4;
+    }
+
+    while (p<bEnd) {
+        h64 ^= (*p) * PRIME64_5;
+        h64 = XXH_rotl64(h64, 11) * PRIME64_1;
+        p++;
+    }
+
+    h64 ^= h64 >> 33;
+    h64 *= PRIME64_2;
+    h64 ^= h64 >> 29;
+    h64 *= PRIME64_3;
+    h64 ^= h64 >> 32;
+
+    return h64;
+}
+
+
+XXH_PUBLIC_API unsigned long long XXH64 (const void* input, size_t len, unsigned long long seed)
+{
+#if 0
+    /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
+    XXH64_state_t state;
+    XXH64_reset(&state, seed);
+    XXH64_update(&state, input, len);
+    return XXH64_digest(&state);
+#else
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if (XXH_FORCE_ALIGN_CHECK) {
+        if ((((size_t)input) & 7)==0) {  /* Input is aligned, let's leverage the speed advantage */
+            if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+                return XXH64_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned);
+            else
+                return XXH64_endian_align(input, len, seed, XXH_bigEndian, XXH_aligned);
+    }   }
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH64_endian_align(input, len, seed, XXH_littleEndian, XXH_unaligned);
+    else
+        return XXH64_endian_align(input, len, seed, XXH_bigEndian, XXH_unaligned);
+#endif
+}
+
+/*======   Hash Streaming   ======*/
+
+XXH_PUBLIC_API XXH64_state_t* XXH64_createState(void)
+{
+    return (XXH64_state_t*)XXH_malloc(sizeof(XXH64_state_t));
+}
+XXH_PUBLIC_API XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr)
+{
+    XXH_free(statePtr);
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API void XXH64_copyState(XXH64_state_t* dstState, const XXH64_state_t* srcState)
+{
+    memcpy(dstState, srcState, sizeof(*dstState));
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, unsigned long long seed)
+{
+    XXH64_state_t state;   /* using a local state to memcpy() in order to avoid strict-aliasing warnings */
+    memset(&state, 0, sizeof(state)-8);   /* do not write into reserved, for future removal */
+    state.v1 = seed + PRIME64_1 + PRIME64_2;
+    state.v2 = seed + PRIME64_2;
+    state.v3 = seed + 0;
+    state.v4 = seed - PRIME64_1;
+    memcpy(statePtr, &state, sizeof(state));
+    return XXH_OK;
+}
+
+FORCE_INLINE XXH_errorcode XXH64_update_endian (XXH64_state_t* state, const void* input, size_t len, XXH_endianess endian)
+{
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* const bEnd = p + len;
+
+    if (input==NULL)
+#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
+        return XXH_OK;
+#else
+        return XXH_ERROR;
+#endif
+
+    state->total_len += len;
+
+    if (state->memsize + len < 32) {  /* fill in tmp buffer */
+        XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, len);
+        state->memsize += (U32)len;
+        return XXH_OK;
+    }
+
+    if (state->memsize) {   /* tmp buffer is full */
+        XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, 32-state->memsize);
+        state->v1 = XXH64_round(state->v1, XXH_readLE64(state->mem64+0, endian));
+        state->v2 = XXH64_round(state->v2, XXH_readLE64(state->mem64+1, endian));
+        state->v3 = XXH64_round(state->v3, XXH_readLE64(state->mem64+2, endian));
+        state->v4 = XXH64_round(state->v4, XXH_readLE64(state->mem64+3, endian));
+        p += 32-state->memsize;
+        state->memsize = 0;
+    }
+
+    if (p+32 <= bEnd) {
+        const BYTE* const limit = bEnd - 32;
+        U64 v1 = state->v1;
+        U64 v2 = state->v2;
+        U64 v3 = state->v3;
+        U64 v4 = state->v4;
+
+        do {
+            v1 = XXH64_round(v1, XXH_readLE64(p, endian)); p+=8;
+            v2 = XXH64_round(v2, XXH_readLE64(p, endian)); p+=8;
+            v3 = XXH64_round(v3, XXH_readLE64(p, endian)); p+=8;
+            v4 = XXH64_round(v4, XXH_readLE64(p, endian)); p+=8;
+        } while (p<=limit);
+
+        state->v1 = v1;
+        state->v2 = v2;
+        state->v3 = v3;
+        state->v4 = v4;
+    }
+
+    if (p < bEnd) {
+        XXH_memcpy(state->mem64, p, (size_t)(bEnd-p));
+        state->memsize = (unsigned)(bEnd-p);
+    }
+
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH64_update (XXH64_state_t* state_in, const void* input, size_t len)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH64_update_endian(state_in, input, len, XXH_littleEndian);
+    else
+        return XXH64_update_endian(state_in, input, len, XXH_bigEndian);
+}
+
+FORCE_INLINE U64 XXH64_digest_endian (const XXH64_state_t* state, XXH_endianess endian)
+{
+    const BYTE * p = (const BYTE*)state->mem64;
+    const BYTE* const bEnd = (const BYTE*)state->mem64 + state->memsize;
+    U64 h64;
+
+    if (state->total_len >= 32) {
+        U64 const v1 = state->v1;
+        U64 const v2 = state->v2;
+        U64 const v3 = state->v3;
+        U64 const v4 = state->v4;
+
+        h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
+        h64 = XXH64_mergeRound(h64, v1);
+        h64 = XXH64_mergeRound(h64, v2);
+        h64 = XXH64_mergeRound(h64, v3);
+        h64 = XXH64_mergeRound(h64, v4);
+    } else {
+        h64  = state->v3 + PRIME64_5;
+    }
+
+    h64 += (U64) state->total_len;
+
+    while (p+8<=bEnd) {
+        U64 const k1 = XXH64_round(0, XXH_readLE64(p, endian));
+        h64 ^= k1;
+        h64  = XXH_rotl64(h64,27) * PRIME64_1 + PRIME64_4;
+        p+=8;
+    }
+
+    if (p+4<=bEnd) {
+        h64 ^= (U64)(XXH_readLE32(p, endian)) * PRIME64_1;
+        h64  = XXH_rotl64(h64, 23) * PRIME64_2 + PRIME64_3;
+        p+=4;
+    }
+
+    while (p<bEnd) {
+        h64 ^= (*p) * PRIME64_5;
+        h64  = XXH_rotl64(h64, 11) * PRIME64_1;
+        p++;
+    }
+
+    h64 ^= h64 >> 33;
+    h64 *= PRIME64_2;
+    h64 ^= h64 >> 29;
+    h64 *= PRIME64_3;
+    h64 ^= h64 >> 32;
+
+    return h64;
+}
+
+XXH_PUBLIC_API unsigned long long XXH64_digest (const XXH64_state_t* state_in)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH64_digest_endian(state_in, XXH_littleEndian);
+    else
+        return XXH64_digest_endian(state_in, XXH_bigEndian);
+}
+
+
+/*====== Canonical representation   ======*/
+
+XXH_PUBLIC_API void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH64_canonical_t) == sizeof(XXH64_hash_t));
+    if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap64(hash);
+    memcpy(dst, &hash, sizeof(*dst));
+}
+
+XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src)
+{
+    return XXH_readBE64(src);
+}
+
+#endif  /* XXH_NO_LONG_LONG */

--- a/util/xxhash.h
+++ b/util/xxhash.h
@@ -1,0 +1,327 @@
+/*
+   xxHash - Extremely Fast Hash algorithm
+   Header File
+   Copyright (C) 2012-2016, Yann Collet.
+
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+   - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+/* Notice extracted from xxHash homepage :
+
+xxHash is an extremely fast Hash algorithm, running at RAM speed limits.
+It also successfully passes all tests from the SMHasher suite.
+
+Comparison (single thread, Windows Seven 32 bits, using SMHasher on a Core 2 Duo
+@3GHz)
+
+Name            Speed       Q.Score   Author
+xxHash          5.4 GB/s     10
+CrapWow         3.2 GB/s      2       Andrew
+MumurHash 3a    2.7 GB/s     10       Austin Appleby
+SpookyHash      2.0 GB/s     10       Bob Jenkins
+SBox            1.4 GB/s      9       Bret Mulvey
+Lookup3         1.2 GB/s      9       Bob Jenkins
+SuperFastHash   1.2 GB/s      1       Paul Hsieh
+CityHash64      1.05 GB/s    10       Pike & Alakuijala
+FNV             0.55 GB/s     5       Fowler, Noll, Vo
+CRC32           0.43 GB/s     9
+MD5-32          0.33 GB/s    10       Ronald L. Rivest
+SHA1-32         0.28 GB/s    10
+
+Q.Score is a measure of quality of the hash function.
+It depends on successfully passing SMHasher test set.
+10 is a perfect score.
+
+A 64-bits version, named XXH64, is available since r35.
+It offers much better speed, but for 64-bits applications only.
+Name     Speed on 64 bits    Speed on 32 bits
+XXH64       13.8 GB/s            1.9 GB/s
+XXH32        6.8 GB/s            6.0 GB/s
+*/
+
+#ifndef XXHASH_H_5627135585666179
+#define XXHASH_H_5627135585666179 1
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/* ****************************
+*  Definitions
+******************************/
+#include <stddef.h> /* size_t */
+typedef enum { XXH_OK = 0, XXH_ERROR } XXH_errorcode;
+
+/* ****************************
+*  API modifier
+******************************/
+/** XXH_PRIVATE_API
+*   This is useful to include xxhash functions in `static` mode
+*   in order to inline them, and remove their symbol from the public list.
+*   Methodology :
+*     #define XXH_PRIVATE_API
+*     #include "xxhash.h"
+*   `xxhash.c` is automatically included.
+*   It's not useful to compile and link it as a separate module.
+*/
+#ifdef XXH_PRIVATE_API
+#ifndef XXH_STATIC_LINKING_ONLY
+#define XXH_STATIC_LINKING_ONLY
+#endif
+#if defined(__GNUC__)
+#define XXH_PUBLIC_API static __inline __attribute__((unused))
+#elif defined(__cplusplus) || \
+    (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+#define XXH_PUBLIC_API static inline
+#elif defined(_MSC_VER)
+#define XXH_PUBLIC_API static __inline
+#else
+#define XXH_PUBLIC_API                                                      \
+  static /* this version may generate warnings for unused static functions; \
+            disable the relevant warning */
+#endif
+#else
+#define XXH_PUBLIC_API /* do nothing */
+#endif                 /* XXH_PRIVATE_API */
+
+/*!XXH_NAMESPACE, aka Namespace Emulation :
+
+If you want to include _and expose_ xxHash functions from within your own
+library,
+but also want to avoid symbol collisions with other libraries which may also
+include xxHash,
+
+you can use XXH_NAMESPACE, to automatically prefix any public symbol from xxhash
+library
+with the value of XXH_NAMESPACE (therefore, avoid NULL and numeric values).
+
+Note that no change is required within the calling program as long as it
+includes `xxhash.h` :
+regular symbol name will be automatically translated by this header.
+*/
+#ifdef XXH_NAMESPACE
+#define XXH_CAT(A, B) A##B
+#define XXH_NAME2(A, B) XXH_CAT(A, B)
+#define XXH_versionNumber XXH_NAME2(XXH_NAMESPACE, XXH_versionNumber)
+#define XXH32 XXH_NAME2(XXH_NAMESPACE, XXH32)
+#define XXH32_createState XXH_NAME2(XXH_NAMESPACE, XXH32_createState)
+#define XXH32_freeState XXH_NAME2(XXH_NAMESPACE, XXH32_freeState)
+#define XXH32_reset XXH_NAME2(XXH_NAMESPACE, XXH32_reset)
+#define XXH32_update XXH_NAME2(XXH_NAMESPACE, XXH32_update)
+#define XXH32_digest XXH_NAME2(XXH_NAMESPACE, XXH32_digest)
+#define XXH32_copyState XXH_NAME2(XXH_NAMESPACE, XXH32_copyState)
+#define XXH32_canonicalFromHash \
+  XXH_NAME2(XXH_NAMESPACE, XXH32_canonicalFromHash)
+#define XXH32_hashFromCanonical \
+  XXH_NAME2(XXH_NAMESPACE, XXH32_hashFromCanonical)
+#define XXH64 XXH_NAME2(XXH_NAMESPACE, XXH64)
+#define XXH64_createState XXH_NAME2(XXH_NAMESPACE, XXH64_createState)
+#define XXH64_freeState XXH_NAME2(XXH_NAMESPACE, XXH64_freeState)
+#define XXH64_reset XXH_NAME2(XXH_NAMESPACE, XXH64_reset)
+#define XXH64_update XXH_NAME2(XXH_NAMESPACE, XXH64_update)
+#define XXH64_digest XXH_NAME2(XXH_NAMESPACE, XXH64_digest)
+#define XXH64_copyState XXH_NAME2(XXH_NAMESPACE, XXH64_copyState)
+#define XXH64_canonicalFromHash \
+  XXH_NAME2(XXH_NAMESPACE, XXH64_canonicalFromHash)
+#define XXH64_hashFromCanonical \
+  XXH_NAME2(XXH_NAMESPACE, XXH64_hashFromCanonical)
+#endif
+
+/* *************************************
+*  Version
+***************************************/
+#define XXH_VERSION_MAJOR 0
+#define XXH_VERSION_MINOR 6
+#define XXH_VERSION_RELEASE 3
+#define XXH_VERSION_NUMBER                                   \
+  (XXH_VERSION_MAJOR * 100 * 100 + XXH_VERSION_MINOR * 100 + \
+   XXH_VERSION_RELEASE)
+XXH_PUBLIC_API unsigned XXH_versionNumber(void);
+
+/*-**********************************************************************
+*  32-bits hash
+************************************************************************/
+typedef unsigned int XXH32_hash_t;
+
+/*! XXH32() :
+    Calculate the 32-bits hash of sequence "length" bytes stored at memory
+   address "input".
+    The memory between input & input+length must be valid (allocated and
+   read-accessible).
+    "seed" can be used to alter the result predictably.
+    Speed on Core 2 Duo @ 3 GHz (single thread, SMHasher benchmark) : 5.4 GB/s
+   */
+XXH_PUBLIC_API XXH32_hash_t XXH32(const void* input, size_t length,
+                                  unsigned int seed);
+
+/*======   Streaming   ======*/
+typedef struct XXH32_state_s XXH32_state_t; /* incomplete type */
+XXH_PUBLIC_API XXH32_state_t* XXH32_createState(void);
+XXH_PUBLIC_API XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr);
+XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* dst_state,
+                                    const XXH32_state_t* src_state);
+
+XXH_PUBLIC_API XXH_errorcode XXH32_reset(XXH32_state_t* statePtr,
+                                         unsigned int seed);
+XXH_PUBLIC_API XXH_errorcode XXH32_update(XXH32_state_t* statePtr,
+                                          const void* input, size_t length);
+XXH_PUBLIC_API XXH32_hash_t XXH32_digest(const XXH32_state_t* statePtr);
+
+/*
+These functions generate the xxHash of an input provided in multiple segments.
+Note that, for small input, they are slower than single-call functions, due to
+state management.
+For small input, prefer `XXH32()` and `XXH64()` .
+
+XXH state must first be allocated, using XXH*_createState() .
+
+Start a new hash by initializing state with a seed, using XXH*_reset().
+
+Then, feed the hash state by calling XXH*_update() as many times as necessary.
+Obviously, input must be allocated and read accessible.
+The function returns an error code, with 0 meaning OK, and any other value
+meaning there is an error.
+
+Finally, a hash value can be produced anytime, by using XXH*_digest().
+This function returns the nn-bits hash as an int or long long.
+
+It's still possible to continue inserting input into the hash state after a
+digest,
+and generate some new hashes later on, by calling again XXH*_digest().
+
+When done, free XXH state space if it was allocated dynamically.
+*/
+
+/*======   Canonical representation   ======*/
+
+typedef struct { unsigned char digest[4]; } XXH32_canonical_t;
+XXH_PUBLIC_API void XXH32_canonicalFromHash(XXH32_canonical_t* dst,
+                                            XXH32_hash_t hash);
+XXH_PUBLIC_API XXH32_hash_t
+XXH32_hashFromCanonical(const XXH32_canonical_t* src);
+
+/* Default result type for XXH functions are primitive unsigned 32 and 64 bits.
+*  The canonical representation uses human-readable write convention, aka
+* big-endian (large digits first).
+*  These functions allow transformation of hash result into and from its
+* canonical format.
+*  This way, hash values can be written into a file / memory, and remain
+* comparable on different systems and programs.
+*/
+
+#ifndef XXH_NO_LONG_LONG
+/*-**********************************************************************
+*  64-bits hash
+************************************************************************/
+typedef unsigned long long XXH64_hash_t;
+
+/*! XXH64() :
+    Calculate the 64-bits hash of sequence of length "len" stored at memory
+   address "input".
+    "seed" can be used to alter the result predictably.
+    This function runs faster on 64-bits systems, but slower on 32-bits systems
+   (see benchmark).
+*/
+XXH_PUBLIC_API XXH64_hash_t XXH64(const void* input, size_t length,
+                                  unsigned long long seed);
+
+/*======   Streaming   ======*/
+typedef struct XXH64_state_s XXH64_state_t; /* incomplete type */
+XXH_PUBLIC_API XXH64_state_t* XXH64_createState(void);
+XXH_PUBLIC_API XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr);
+XXH_PUBLIC_API void XXH64_copyState(XXH64_state_t* dst_state,
+                                    const XXH64_state_t* src_state);
+
+XXH_PUBLIC_API XXH_errorcode XXH64_reset(XXH64_state_t* statePtr,
+                                         unsigned long long seed);
+XXH_PUBLIC_API XXH_errorcode XXH64_update(XXH64_state_t* statePtr,
+                                          const void* input, size_t length);
+XXH_PUBLIC_API XXH64_hash_t XXH64_digest(const XXH64_state_t* statePtr);
+
+/*======   Canonical representation   ======*/
+typedef struct { unsigned char digest[8]; } XXH64_canonical_t;
+XXH_PUBLIC_API void XXH64_canonicalFromHash(XXH64_canonical_t* dst,
+                                            XXH64_hash_t hash);
+XXH_PUBLIC_API XXH64_hash_t
+XXH64_hashFromCanonical(const XXH64_canonical_t* src);
+#endif /* XXH_NO_LONG_LONG */
+
+#ifdef XXH_STATIC_LINKING_ONLY
+
+/* ================================================================================================
+   This section contains definitions which are not guaranteed to remain stable.
+   They may change in future versions, becoming incompatible with a different
+version of the library.
+   They shall only be used with static linking.
+   Never use these definitions in association with dynamic linking !
+===================================================================================================
+*/
+
+/* These definitions are only meant to make possible
+   static allocation of XXH state, on stack or in a struct for example.
+   Never use members directly. */
+
+struct XXH32_state_s {
+  unsigned total_len_32;
+  unsigned large_len;
+  unsigned v1;
+  unsigned v2;
+  unsigned v3;
+  unsigned v4;
+  unsigned mem32[4]; /* buffer defined as U32 for alignment */
+  unsigned memsize;
+  unsigned
+      reserved; /* never read nor write, will be removed in a future version */
+};              /* typedef'd to XXH32_state_t */
+
+#ifndef XXH_NO_LONG_LONG /* remove 64-bits support */
+struct XXH64_state_s {
+  unsigned long long total_len;
+  unsigned long long v1;
+  unsigned long long v2;
+  unsigned long long v3;
+  unsigned long long v4;
+  unsigned long long mem64[4]; /* buffer defined as U64 for alignment */
+  unsigned memsize;
+  unsigned reserved[2]; /* never read nor write, will be removed in a future
+                           version */
+};                      /* typedef'd to XXH64_state_t */
+#endif
+
+#ifdef XXH_PRIVATE_API
+#include "xxhash.c" /* include xxhash function bodies as `static`, for inlining */
+#endif
+
+#endif /* XXH_STATIC_LINKING_ONLY */
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* XXHASH_H_5627135585666179 */


### PR DESCRIPTION
Use a simple string interning implementation based on
`std::unordered_map` to reduce memory usage. In addition switch the
`Tags` map to use `unordered_map` instead of the tree based `std::map`.
A benchmark shows the memory usage for sending 50,000 counters each with
10 tags (plus common tags) goes down from 250MB to 40-49MB.  No leaks
are detected, but we don't free the strings which means memory usage
will go up if new tag values keep getting added to the pool.

The CPU based benchmark shows a big chunk of time is spent in
`Tags(const Tags& source)` and `Tags::add_all(Tags& more_tags)`, which
suggests we should look into optimizing the `Tags` implementation
(switching from a `std::unordered_map<StrRef,StrRef>` to a custom small
hash table implementation.  That work is left for a future PR.

I've tested two open source string interning libraries:

* https://github.com/RipcordSoftware/libstringintern

* https://github.com/chriso/intern

The first failed at handling empty strings, and the second failed by
giving the same ID to different strings (after inserting about 370
distinct strings).

I also looked at the `StringPool` implementation in clang, which looks
very promising including the removal of unused strings, but it requires
too many extra bits from clang, and the switch to using `StringRef`
instead of strings.