### PR TITLE
Do batching with iterators, not copies

### DIFF
--- a/meter/id.h
+++ b/meter/id.h
@@ -82,7 +82,7 @@ class Tags {
     if (it != entries_.end()) {
       return it->second;
     }
-    return util::intern_str(""); // cannot throw exceptions on nodejs
+    return util::intern_str("");  // cannot throw exceptions on nodejs
   }
 
   size_t size() const { return entries_.size(); }


### PR DESCRIPTION
Reduces the memory usage needed when dealing with more than one batch of
metrics (10,000 by default) by eliminating the copies to the temporary
vectors used for batching. Now we just pass iterators to the beginning
and end of the range.