### PR TITLE
Add a couple of gauges to track string pool usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # We need to initialize intern.cc first, since other files depend on it
 # for interning strings directly or indirectly using static Tags
 set(LIB_SOURCE_FILES
-    util/intern.cc util/xxhash.c util/config.cc util/config_manager.cc util/environment.cc
-    util/gzip.cc util/http.cc util/logger.cc util/strings.cc atlas_client.cc 
+    util/string_pool.cc util/intern.cc util/xxhash.c util/config.cc util/config_manager.cc util/environment.cc
+    util/gzip.cc util/http.cc util/logger.cc util/strings.cc atlas_client.cc
     meter/bucket_counter.cc meter/bucket_distribution_summary.cc meter/bucket_functions.cc
     meter/bucket_timer.cc meter/clock.cc meter/id.cc meter/interval_counter.cc meter/monotonic_counter.cc
     meter/percentile_buckets.cc meter/percentile_dist_summary.cc meter/percentile_timer.cc meter/statistic.cc

--- a/meter/subscription_manager.h
+++ b/meter/subscription_manager.h
@@ -46,6 +46,8 @@ class SubscriptionManager {
   void RefreshSubscriptions(const std::string& subs_endpoint);
 
   void SendToMain();
+
+  void UpdateMetrics() noexcept;
 };
 }  // namespace meter
 }  // namespace atlas

--- a/test/interpreter_test.cc
+++ b/test/interpreter_test.cc
@@ -215,9 +215,6 @@ TEST(Interpreter, DropTags) {
   auto all = std::static_pointer_cast<MultipleResults>(expr);
 
   auto measurements = get_measurements();
-  for (const auto& m : measurements) {
-    Logger()->info("M: {}", m);
-  }
   auto res = all->Apply(measurements);
   EXPECT_EQ(res.size(), 2);
 

--- a/util/intern.cc
+++ b/util/intern.cc
@@ -1,55 +1,11 @@
 #include "intern.h"
-#include "xxhash.h"
-#include <cassert>
-#include <cstring>
-#include <mutex>
-#include <unordered_map>
+#include "string_pool.h"
 
 namespace atlas {
 namespace util {
 
-struct Hasher {
-  size_t operator()(const char* str) const {
-    return XXH64(str, strlen(str), 42);
-  }
-};
-
-struct Comparer {
-  bool operator()(const char* s1, const char* s2) const {
-    return std::strcmp(s1, s2) == 0;
-  }
-};
-
-class StringPool {
- public:
-  StringPool() noexcept {}
-  ~StringPool() noexcept = default;
-  StringPool(const StringPool& pool) = delete;
-  StringPool& operator=(const StringPool& pool) = delete;
-
-  const StrRef& intern(const char* string) {
-    std::lock_guard<std::mutex> guard(mutex);
-    auto it = table.find(string);
-    if (it != table.end()) {
-      return it->second;
-    }
-    const auto* copy = strdup(string);
-    StrRef ref;
-    ref.data = copy;
-    table.insert(std::make_pair(copy, ref));
-    return table.at(copy);
-  }
-
- private:
-  std::unordered_map<const char*, StrRef, Hasher, Comparer> table;
-
-  std::mutex mutex;
-};
-
-static StringPool the_pool;
-
 const StrRef& intern_str(const char* string) {
-  const auto& r = the_pool.intern(string);
+  const auto& r = the_str_pool.intern(string);
 #ifdef DEBUG
   if (strcmp(string, r.get()) != 0) {
     printf("Unable to intern %s = %s -> %s\n", string, r.data, r.get());

--- a/util/string_pool.cc
+++ b/util/string_pool.cc
@@ -1,0 +1,30 @@
+#include "string_pool.h"
+
+namespace atlas {
+namespace util {
+
+StringPool the_str_pool;
+
+StringPool::~StringPool() noexcept {
+  for (const auto& kv : table) {
+    auto copy = static_cast<void*>(const_cast<char*>(kv.first));
+    free(copy);
+  }
+}
+
+const StrRef& StringPool::intern(const char* string) noexcept {
+  std::lock_guard<std::mutex> guard(mutex);
+  auto it = table.find(string);
+  if (it != table.end()) {
+    return it->second;
+  }
+  const auto* copy = strdup(string);
+  StrRef ref;
+  ref.data = copy;
+  table.insert(std::make_pair(copy, ref));
+  alloc_size_ += strlen(copy) + 1;  // null terminator
+  return table.at(copy);
+}
+
+}  // namespace util
+}  // namespace atlas

--- a/util/string_pool.h
+++ b/util/string_pool.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "intern.h"
+#include "xxhash.h"
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <unordered_map>
+
+namespace atlas {
+namespace util {
+
+struct CStrHasher {
+  size_t operator()(const char* str) const {
+    return XXH64(str, std::strlen(str), 42);
+  }
+};
+
+struct CStrComparer {
+  bool operator()(const char* s1, const char* s2) const {
+    return std::strcmp(s1, s2) == 0;
+  }
+};
+
+class StringPool {
+ public:
+  StringPool() noexcept {}
+  ~StringPool() noexcept;
+  StringPool(const StringPool& pool) = delete;
+  StringPool& operator=(const StringPool& pool) = delete;
+
+  const StrRef& intern(const char* string) noexcept;
+
+  size_t pool_size() const noexcept { return table.size(); }
+
+  size_t alloc_size() const noexcept { return alloc_size_; }
+
+ private:
+  std::unordered_map<const char*, StrRef, CStrHasher, CStrComparer> table;
+  size_t alloc_size_ = 0;
+
+  std::mutex mutex;
+};
+
+extern StringPool the_str_pool;
+}
+}


### PR DESCRIPTION
Adds `atlas.client.strPoolSize` and `atlas.client.strPoolAlloc` to track
the number of strings and bytes handled by our string pool.