### PR TITLE
Prevent the static initialization order fiasco

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ set(PROJECT_NAME_STR libatlasclient)
 set(CMAKE_MACOSX_RPATH 1)
 project(${PROJECT_NAME_STR})
 
-
 include_directories(3rd-party /usr/local/include)
 link_directories(/usr/local/lib)
 
@@ -14,19 +13,11 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# We need to initialize intern.cc first, since other files depend on it
-# for interning strings directly or indirectly using static Tags
-set(LIB_SOURCE_FILES
-    util/string_pool.cc util/intern.cc util/xxhash.c util/config.cc util/config_manager.cc util/environment.cc
-    util/gzip.cc util/http.cc util/logger.cc util/strings.cc atlas_client.cc
-    meter/bucket_counter.cc meter/bucket_distribution_summary.cc meter/bucket_functions.cc
-    meter/bucket_timer.cc meter/clock.cc meter/id.cc meter/interval_counter.cc meter/monotonic_counter.cc
-    meter/percentile_buckets.cc meter/percentile_dist_summary.cc meter/percentile_timer.cc meter/statistic.cc
-    meter/subscription_gauge.cc meter/subscription_long_task_timer.cc meter/subscription_manager.cc
-    meter/subscription_registry.cc meter/subscription_timer.cc meter/validation.cc
-    interpreter/aggregation.cc interpreter/all.cc interpreter/context.cc interpreter/expression.cc
-    interpreter/group_by.cc interpreter/interpreter.cc interpreter/keep_drop_tags.cc
-    interpreter/multiple_results.cc interpreter/query.cc interpreter/vocabulary.cc)
+file(GLOB LIB_SOURCE_FILES
+  atlas_client.cc atlas_client.h types.h
+  meter/*.h meter/*.cc
+  util/*.h util/*.cc
+  interpreter/*.h interpreter/*.cc)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic -Werror -Wall -std=c99 -fpic -D_GNU_SOURCE")
 set(CMAKE_C_FLAGS_RELEASE "-O3 -march=native")

--- a/meter/subscription_manager.cc
+++ b/meter/subscription_manager.cc
@@ -504,8 +504,8 @@ void SubscriptionManager::UpdateMetrics() noexcept {
   static auto pool_size = atlas_registry.gauge("atlas.client.strPoolSize");
   static auto pool_alloc = atlas_registry.gauge("atlas.client.strPoolAlloc");
 
-  pool_size->Update(util::the_str_pool.pool_size());
-  pool_alloc->Update(util::the_str_pool.alloc_size());
+  pool_size->Update(util::the_str_pool().pool_size());
+  pool_alloc->Update(util::the_str_pool().alloc_size());
 }
 
 void SubscriptionManager::SendToMain() {

--- a/util/intern.cc
+++ b/util/intern.cc
@@ -5,7 +5,7 @@ namespace atlas {
 namespace util {
 
 const StrRef& intern_str(const char* string) {
-  const auto& r = the_str_pool.intern(string);
+  const auto& r = the_str_pool().intern(string);
 #ifdef DEBUG
   if (strcmp(string, r.get()) != 0) {
     printf("Unable to intern %s = %s -> %s\n", string, r.data, r.get());

--- a/util/string_pool.cc
+++ b/util/string_pool.cc
@@ -3,7 +3,10 @@
 namespace atlas {
 namespace util {
 
-StringPool the_str_pool;
+StringPool& the_str_pool() {
+  static StringPool* the_pool = new StringPool();
+  return *the_pool;
+}
 
 StringPool::~StringPool() noexcept {
   for (const auto& kv : table) {

--- a/util/string_pool.h
+++ b/util/string_pool.h
@@ -42,6 +42,6 @@ class StringPool {
   std::mutex mutex;
 };
 
-extern StringPool the_str_pool;
+StringPool& the_str_pool();
 }
 }


### PR DESCRIPTION
We were relying on the linker honoring the order of the object files,
but it's not reliable. We found a problem when users were using the
static library generated. Switch to an 'Construct On First Use' idiom to
avoid relying on the initialization order.