### PR TITLE
Expose UseConsoleLogger

### DIFF
--- a/atlas_client.cc
+++ b/atlas_client.cc
@@ -131,3 +131,5 @@ void PushMeasurements(const atlas::meter::Measurements& measurements) {
 void SetLoggingDirs(const std::vector<std::string>& dirs) {
   atlas::util::SetLoggingDirs(dirs);
 }
+
+void UseConsoleLogger(int level) { atlas::util::UseConsoleLogger(level); }

--- a/atlas_client.h
+++ b/atlas_client.h
@@ -12,3 +12,4 @@ extern atlas::meter::SubscriptionRegistry atlas_registry;
 atlas::util::Config GetConfig();
 void PushMeasurements(const atlas::meter::Measurements& measurements);
 void SetLoggingDirs(const std::vector<std::string>& dirs);
+void UseConsoleLogger(int level);

--- a/main.cc
+++ b/main.cc
@@ -20,7 +20,7 @@ void init_tags(Tags* tags) {
 }
 
 int main(int argc, char* argv[]) {
-  atlas::util::UseConsoleLogger();
+  atlas::util::UseConsoleLogger(1);
   auto logger = atlas::util::Logger();
   InitAtlas();
 

--- a/test/runtests.cc
+++ b/test/runtests.cc
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 
 int main(int argc, char** argv) {
-  atlas::util::UseConsoleLogger();
+  atlas::util::UseConsoleLogger(1);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/util/logger.cc
+++ b/util/logger.cc
@@ -120,7 +120,7 @@ void SetLoggingLevel(int level) noexcept {
   Logger()->set_level(level_from_int(level));
 }
 
-void UseConsoleLogger() noexcept {
+void UseConsoleLogger(int level) noexcept {
   std::lock_guard<std::mutex> lock(logger_mutex);
   auto logger = spdlog::get(kMainLogger);
   if (logger) {
@@ -128,7 +128,7 @@ void UseConsoleLogger() noexcept {
   }
 
   logger = spdlog::stdout_color_mt(kMainLogger);
-  logger->set_level(spdlog::level::debug);
+  logger->set_level(level_from_int(level));
   current_logging_directory = "";
 }
 

--- a/util/logger.h
+++ b/util/logger.h
@@ -7,7 +7,7 @@ namespace atlas {
 namespace util {
 
 std::shared_ptr<spdlog::logger> Logger() noexcept;
-void UseConsoleLogger() noexcept;
+void UseConsoleLogger(int level) noexcept;
 void SetLoggingLevel(int level) noexcept;
 void SetLoggingDirs(const std::vector<std::string>& dirs) noexcept;
 std::string GetLoggingDir() noexcept;


### PR DESCRIPTION
Allow users of the library to request a console logger with a certain
verbosity. (1 == debug, 2 == info, etc.)