### PR TITLE
Add ability to enable/disable atlas using a file

### DIFF
--- a/util/config.cc
+++ b/util/config.cc
@@ -8,7 +8,8 @@
 namespace atlas {
 namespace util {
 
-Config::Config(const std::string& evaluate_endpoint,
+Config::Config(const std::string& disabled_file,
+               const std::string& evaluate_endpoint,
                const std::string& subscriptions_endpoint,
                const std::string& publish_endpoint, bool validate_metrics,
                const std::string& check_cluster_endpoint,
@@ -18,7 +19,8 @@ Config::Config(const std::string& evaluate_endpoint,
                bool enable_main, bool enable_subscriptions, bool dump_metrics,
                bool dump_subscriptions, int log_verbosity,
                meter::Tags common_tags) noexcept
-    : evaluate_endpoint_(ExpandEnvVars(evaluate_endpoint)),
+    : disabled_file_watcher_(disabled_file),
+      evaluate_endpoint_(ExpandEnvVars(evaluate_endpoint)),
       subscriptions_endpoint_(ExpandEnvVars(subscriptions_endpoint)),
       publish_endpoint_(ExpandEnvVars(publish_endpoint)),
       validate_metrics_(validate_metrics),
@@ -39,6 +41,16 @@ Config::Config(const std::string& evaluate_endpoint,
 
 std::string Config::LoggingDirectory() const noexcept {
   return GetLoggingDir();
+}
+
+bool Config::IsMainEnabled() const noexcept {
+  bool disabled = disabled_file_watcher_.exists();
+  return !disabled && enable_main_;
+}
+
+bool Config::AreSubsEnabled() const noexcept {
+  bool disabled = disabled_file_watcher_.exists();
+  return !disabled && enable_subscriptions_;
 }
 
 std::string ConfigToString(const Config& config) noexcept {

--- a/util/config.h
+++ b/util/config.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include "../meter/id.h"
+#include "file_watcher.h"
 
 namespace atlas {
 namespace util {
@@ -14,7 +15,7 @@ static constexpr int kMainFrequencyMillis{60000};
 
 class Config {
  public:
-  Config(const std::string& evaluate_endpoint,
+  Config(const std::string& disabled_file, const std::string& evaluate_endpoint,
          const std::string& subscriptions_endpoint,
          const std::string& publish_endpoint, bool validate_metrics,
          const std::string& check_cluster_endpoint, bool notifyAlertServer,
@@ -37,8 +38,8 @@ class Config {
   bool ShouldValidateMetrics() const noexcept { return validate_metrics_; }
   bool ShouldForceStart() const noexcept { return force_start_; }
   bool ShouldNotifyAlertServer() const noexcept { return notify_alert_server_; }
-  bool IsMainEnabled() const noexcept { return enable_main_; }
-  bool AreSubsEnabled() const noexcept { return enable_subscriptions_; }
+  bool IsMainEnabled() const noexcept;
+  bool AreSubsEnabled() const noexcept;
   bool ShouldDumpMetrics() const noexcept { return dump_metrics_; }
   bool ShouldDumpSubs() const noexcept { return dump_subscriptions_; }
   std::string PublishEndpoint() const noexcept { return publish_endpoint_; }
@@ -50,8 +51,12 @@ class Config {
   void AddCommonTags(const meter::Tags& extra_tags) noexcept {
     common_tags_.add_all(extra_tags);
   }
+  std::string DisabledFile() const noexcept {
+    return disabled_file_watcher_.file_name();
+  }
 
  private:
+  FileWatcher disabled_file_watcher_;
   std::string evaluate_endpoint_;
   std::string subscriptions_endpoint_;
   std::string publish_endpoint_;

--- a/util/config_manager.cc
+++ b/util/config_manager.cc
@@ -31,6 +31,7 @@ static const char* kCheckClusterUrl =
     "net/"
     "alertchecker/checkCluster/$NETFLIX_CLUSTER";
 static const char* kPublishExpr = ":true,:all";
+static const char* kDefaultDisabledFile = "/mnt/data/atlas.disabled";
 
 static const std::vector<std::string> kPublishConfig{kPublishExpr};
 constexpr int kDefaultVerbosity = 2;
@@ -145,11 +146,11 @@ static std::unique_ptr<Config> DocToConfig(
                            : defaults->LogVerbosity();
 
   return std::make_unique<Config>(
-      eval_url, sub_endpoint, publish_endpoint, validate_metrics,
-      check_cluster_endpoint, notify_alert_server, publish_config, sub_refresh,
-      connect_timeout, read_timeout, batch_size, force_start, main_enabled,
-      subs_enabled, dump_metrics, dump_subscriptions, log_verbosity,
-      get_default_common_tags());
+      defaults->DisabledFile(), eval_url, sub_endpoint, publish_endpoint,
+      validate_metrics, check_cluster_endpoint, notify_alert_server,
+      publish_config, sub_refresh, connect_timeout, read_timeout, batch_size,
+      force_start, main_enabled, subs_enabled, dump_metrics, dump_subscriptions,
+      log_verbosity, get_default_common_tags());
 }
 
 static std::unique_ptr<Config> ParseConfigFile(
@@ -175,8 +176,13 @@ static std::unique_ptr<Config> ParseConfigFile(
 }
 
 std::unique_ptr<Config> DefaultConfig() noexcept {
+  const char* disabled_file = std::getenv("ATLAS_DISABLED_FILE");
+  if (disabled_file == nullptr) {
+    disabled_file = kDefaultDisabledFile;
+  }
+
   return std::make_unique<Config>(
-      std::string(kEvaluateUrl), std::string(kSubscriptionsUrl),
+      disabled_file, std::string(kEvaluateUrl), std::string(kSubscriptionsUrl),
       std::string(kPublishUrl), kValidateMetrics, std::string(kCheckClusterUrl),
       // notify alert-server we do not support on-instance alerts
       true, kPublishConfig, kRefresherMillis, kConnectTimeout, kReadTimeout,

--- a/util/file_watcher.h
+++ b/util/file_watcher.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <unistd.h>
+
+namespace atlas {
+namespace util {
+
+class FileWatcher {
+ public:
+  explicit FileWatcher(std::string file_name) noexcept
+      : file_name_(std::move(file_name)),
+        last_updated_(now()),
+        exists_(access(file_name_.c_str(), F_OK) != -1) {}
+
+  FileWatcher(const FileWatcher& other) noexcept
+      : file_name_(other.file_name_),
+        last_updated_(other.last_updated_.load(std::memory_order_relaxed)),
+        exists_(other.exists_.load(std::memory_order_relaxed)) {}
+  FileWatcher(FileWatcher&& other) noexcept
+      : file_name_(std::move(other.file_name_)),
+        last_updated_(other.last_updated_.load(std::memory_order_relaxed)),
+        exists_(other.exists_.load(std::memory_order_relaxed)) {}
+
+  bool exists() const noexcept {
+    auto last = last_updated_.load(std::memory_order_relaxed);
+    auto ts = now();
+    if ((ts - last) > kMaxStaleMillis) {
+      exists_.store(access(file_name_.c_str(), F_OK) != -1,
+                    std::memory_order_relaxed);
+      last_updated_.store(ts, std::memory_order_relaxed);
+    }
+    return exists_.load(std::memory_order_relaxed);
+  }
+
+  std::string file_name() const noexcept { return file_name_; }
+
+ private:
+  static constexpr int kMaxStaleMillis = 2000;
+  static int64_t now() {
+    return std::chrono::system_clock::now().time_since_epoch().count();
+  }
+
+  std::string file_name_;
+  mutable std::atomic<int64_t> last_updated_;
+  mutable std::atomic<bool> exists_;
+};
+
+}  // namespace util
+}  // namespace atlas


### PR DESCRIPTION
Provide a mechanism to enable/disable the publishing of metrics and
doing subscription based work depending on whether a file is abset/present
on the filesystem.