### PR TITLE
Set notify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ file(GLOB LIB_SOURCE_FILES
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic -Werror -Wall -std=c99 -fpic -D_GNU_SOURCE")
 set(CMAKE_C_FLAGS_RELEASE "-O3 -march=native")
+set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 
 add_library(atlasclient SHARED ${LIB_SOURCE_FILES})
 set_target_properties(atlasclient PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wno-missing-braces")

--- a/atlas_client.cc
+++ b/atlas_client.cc
@@ -88,6 +88,10 @@ class AtlasClient {
     config_manager.AddCommonTag(key, value);
   }
 
+  void SetNotifyAlertServer(bool notify) {
+    config_manager.SetNotifyAlertServer(notify);
+  }
+
  private:
   bool started;
   ConfigManager config_manager;
@@ -115,7 +119,8 @@ void AtlasAddCommonTag(const char* key, const char* value) {
   }
 }
 
-atlas::util::Config GetConfig() {
+namespace atlas {
+util::Config GetConfig() {
   if (atlas_client) {
     return *atlas_client->GetConfig();
   }
@@ -133,3 +138,10 @@ void SetLoggingDirs(const std::vector<std::string>& dirs) {
 }
 
 void UseConsoleLogger(int level) { atlas::util::UseConsoleLogger(level); }
+
+void SetNotifyAlertServer(bool notify) {
+  if (atlas_client) {
+    atlas_client->SetNotifyAlertServer(notify);
+  }
+}
+}  // namespace atlas

--- a/atlas_client.h
+++ b/atlas_client.h
@@ -9,7 +9,24 @@ extern "C" void AtlasAddCommonTag(const char* key, const char* value);
 
 extern atlas::meter::SubscriptionRegistry atlas_registry;
 
-atlas::util::Config GetConfig();
+namespace atlas {
+util::Config GetConfig();
 void PushMeasurements(const atlas::meter::Measurements& measurements);
 void SetLoggingDirs(const std::vector<std::string>& dirs);
 void UseConsoleLogger(int level);
+void SetNotifyAlertServer(bool notify);
+}
+
+/* Deprecated functions. Please use functions in namespace atlas instead. */
+inline atlas::util::Config GetConfig() { return atlas::GetConfig(); }
+
+inline void PushMeasurements(const atlas::meter::Measurements& measurements) {
+  atlas::PushMeasurements(measurements);
+}
+
+inline void SetLoggingDirs(const std::vector<std::string>& dirs) {
+  atlas::SetLoggingDirs(dirs);
+}
+
+inline void UseConsoleLogger(int level) { atlas::UseConsoleLogger(level); }
+/* End deprecated functions */

--- a/meter/function_gauge.h
+++ b/meter/function_gauge.h
@@ -2,6 +2,7 @@
 
 #include "gauge.h"
 #include "registry.h"
+#include <functional>
 
 namespace atlas {
 namespace meter {

--- a/util/config_manager.h
+++ b/util/config_manager.h
@@ -11,7 +11,7 @@
 namespace atlas {
 namespace util {
 
-std::unique_ptr<Config> DefaultConfig() noexcept;
+std::unique_ptr<Config> DefaultConfig(bool default_notify = true) noexcept;
 
 class ConfigManager {
  public:
@@ -25,14 +25,18 @@ class ConfigManager {
 
   void AddCommonTag(const char* key, const char* value) noexcept;
 
+  void SetNotifyAlertServer(bool notify) noexcept;
+
  private:
   mutable std::mutex config_mutex;
   std::shared_ptr<Config> current_config_;
   std::atomic<bool> should_run_{false};
   meter::Tags extra_tags_;
+  bool default_notify_ = true;
 
   void refresher() noexcept;
   void refresh_configs() noexcept;
+  std::unique_ptr<Config> get_current_config() noexcept;
 };
 }
 }


### PR DESCRIPTION
Currently the library notifies alert-server that we don't support
on-instance alerts. This was somewhat appropriate when there would be
only one atlas-client on the machine. Either the java client or this
native client, but now we have more users (like a system-agent) that
is likely to be installed alongside a jvm app, using the java client.

This PR adds a new function that can be used by system agents to opt-out
of notifying the alert server of lack of on-instance alerts.