### PR TITLE
Move global functions to the atlas namespace

### DIFF
--- a/atlas_client.cc
+++ b/atlas_client.cc
@@ -100,25 +100,6 @@ class AtlasClient {
 
 static auto atlas_client = std::unique_ptr<AtlasClient>(nullptr);
 
-void InitAtlas() {
-  if (!atlas_client) {
-    atlas_client.reset(new AtlasClient());
-  }
-  atlas_client->Start();
-}
-
-void ShutdownAtlas() {
-  if (atlas_client) {
-    atlas_client->Stop();
-  }
-}
-
-void AtlasAddCommonTag(const char* key, const char* value) {
-  if (atlas_client) {
-    atlas_client->AddCommonTag(key, value);
-  }
-}
-
 namespace atlas {
 util::Config GetConfig() {
   if (atlas_client) {
@@ -144,4 +125,37 @@ void SetNotifyAlertServer(bool notify) {
     atlas_client->SetNotifyAlertServer(notify);
   }
 }
+
+void Init() {
+  if (!atlas_client) {
+    atlas_client.reset(new AtlasClient());
+  }
+  atlas_client->Start();
+}
+
+void Shutdown() {
+  if (atlas_client) {
+    atlas_client->Stop();
+  }
+}
+
+void AddCommonTag(const char* key, const char* value) {
+  if (atlas_client) {
+    atlas_client->AddCommonTag(key, value);
+  }
+}
+
 }  // namespace atlas
+
+void InitAtlas() {
+  atlas::Init();
+}
+
+void ShutdownAtlas() {
+  atlas::Shutdown();
+}
+
+void AtlasAddCommonTag(const char* key, const char* value) {
+  atlas::AddCommonTag(key, value);
+}
+

--- a/atlas_client.h
+++ b/atlas_client.h
@@ -3,21 +3,25 @@
 #include "meter/subscription_registry.h"
 #include <vector>
 
-extern "C" void InitAtlas();
-extern "C" void ShutdownAtlas();
-extern "C" void AtlasAddCommonTag(const char* key, const char* value);
 
 extern atlas::meter::SubscriptionRegistry atlas_registry;
 
 namespace atlas {
+void Init();
+void Shutdown();
+void AddCommonTag(const char* key, const char* value);
 util::Config GetConfig();
 void PushMeasurements(const atlas::meter::Measurements& measurements);
 void SetLoggingDirs(const std::vector<std::string>& dirs);
 void UseConsoleLogger(int level);
 void SetNotifyAlertServer(bool notify);
-}
+}  // namespace atlas
 
-/* Deprecated functions. Please use functions in namespace atlas instead. */
+/* Deprecated functions. Please use functions in namespace atlasclient instead. */
+extern "C" void InitAtlas();
+extern "C" void ShutdownAtlas();
+extern "C" void AtlasAddCommonTag(const char* key, const char* value);
+
 inline atlas::util::Config GetConfig() { return atlas::GetConfig(); }
 
 inline void PushMeasurements(const atlas::meter::Measurements& measurements) {


### PR DESCRIPTION
Deprecated global functions that are not in the atlas namespace. The
`extern "C"` versions are not particularly useful, since you need C++ to
use the library. The original intention was to provide a C interface,
but that is not available, and it would require significant effort to
do.