### PR TITLE
Add value of notify to debug output of a config 

### DIFF
--- a/meter/subscription_registry.cc
+++ b/meter/subscription_registry.cc
@@ -148,20 +148,6 @@ void SubscriptionRegistry::RegisterMonitor(
   InsertIfNeeded(meter);
 }
 
-// FIXME: test
-std::shared_ptr<interpreter::Query> QueryForSubs(
-    const interpreter::Interpreter& inter, const Subscriptions& subscriptions) {
-  using interpreter::Query;
-  using interpreter::query::false_q;
-  using interpreter::query::or_q;
-  return std::accumulate(
-      subscriptions.begin(), subscriptions.end(),
-      std::shared_ptr<interpreter::Query>(false_q()),
-      [&inter](std::shared_ptr<Query>& q, const Subscription& s) {
-        return or_q(q, inter.GetQuery(s.expression));
-      });
-}
-
 static void LogRules(const std::vector<std::string>& rules,
                      size_t num_measurements) {
   auto logger = Logger();

--- a/util/config.cc
+++ b/util/config.cc
@@ -60,6 +60,7 @@ std::string ConfigToString(const Config& config) noexcept {
      << ", subs_endpoint=" << config.SubsEndpoint() << '\n'
      << ", subs_refresh=" << config.SubRefreshMillis() << "ms"
      << ", publish=" << config.PublishEndpoint() << '\n'
+     << ", notifyAlertServer=" << config.ShouldNotifyAlertServer() << '\n'
      << ", validateMetrics=" << config.ShouldValidateMetrics() << '\n'
      << ", forceStart=" << config.ShouldForceStart()
      << ", mainEnabled=" << config.IsMainEnabled() << '\n'

--- a/util/config_manager.cc
+++ b/util/config_manager.cc
@@ -176,7 +176,7 @@ static std::unique_ptr<Config> ParseConfigFile(
   return defaults;
 }
 
-std::unique_ptr<Config> DefaultConfig(bool default_notify) noexcept {
+std::unique_ptr<Config> DefaultConfig(bool notify) noexcept {
   const char* disabled_file = std::getenv("ATLAS_DISABLED_FILE");
   if (disabled_file == nullptr) {
     disabled_file = kDefaultDisabledFile;
@@ -185,8 +185,8 @@ std::unique_ptr<Config> DefaultConfig(bool default_notify) noexcept {
   return std::make_unique<Config>(
       disabled_file, std::string(kEvaluateUrl), std::string(kSubscriptionsUrl),
       std::string(kPublishUrl), kValidateMetrics, std::string(kCheckClusterUrl),
-      // notify alert-server we do not support on-instance alerts
-      default_notify, kPublishConfig, kRefresherMillis, kConnectTimeout,
+      notify, // whether to notify alert-server about on-instance alert support
+      kPublishConfig, kRefresherMillis, kConnectTimeout,
       kReadTimeout, kBatchSize,
       // do not run on dev env
       false,

--- a/util/config_manager.h
+++ b/util/config_manager.h
@@ -11,7 +11,7 @@
 namespace atlas {
 namespace util {
 
-std::unique_ptr<Config> DefaultConfig(bool default_notify = true) noexcept;
+std::unique_ptr<Config> DefaultConfig(bool notify = true) noexcept;
 
 class ConfigManager {
  public:


### PR DESCRIPTION
This can make it easier to debug certain problems when the value of the
config object is different from the expected value.

