### PR TITLE
Switch tags implementation to use a custom map

### DIFF
--- a/atlas_client.cc
+++ b/atlas_client.cc
@@ -147,15 +147,10 @@ void AddCommonTag(const char* key, const char* value) {
 
 }  // namespace atlas
 
-void InitAtlas() {
-  atlas::Init();
-}
+void InitAtlas() { atlas::Init(); }
 
-void ShutdownAtlas() {
-  atlas::Shutdown();
-}
+void ShutdownAtlas() { atlas::Shutdown(); }
 
 void AtlasAddCommonTag(const char* key, const char* value) {
   atlas::AddCommonTag(key, value);
 }
-

--- a/atlas_client.h
+++ b/atlas_client.h
@@ -3,7 +3,6 @@
 #include "meter/subscription_registry.h"
 #include <vector>
 
-
 extern atlas::meter::SubscriptionRegistry atlas_registry;
 
 namespace atlas {
@@ -17,7 +16,8 @@ void UseConsoleLogger(int level);
 void SetNotifyAlertServer(bool notify);
 }  // namespace atlas
 
-/* Deprecated functions. Please use functions in namespace atlasclient instead. */
+/* Deprecated functions. Please use functions in namespace atlasclient instead.
+ */
 extern "C" void InitAtlas();
 extern "C" void ShutdownAtlas();
 extern "C" void AtlasAddCommonTag(const char* key, const char* value);

--- a/bench/tags.cc
+++ b/bench/tags.cc
@@ -1,4 +1,6 @@
 #include "../util/intern.h"
+#include "../meter/id.h"
+#include "../util/small_tag_map.h"
 #include <benchmark/benchmark.h>
 #include <unordered_map>
 
@@ -38,23 +40,48 @@ class Tags {
   }
 };
 
-template <typename C>
+
+class VectorTags {
+  using value_t = util::StrRef;
+  using entry_t = std::pair<value_t, value_t>;
+ public:
+  void add(const char* k, const char* v) {
+    entries_.emplace_back(util::intern_str(k), util::intern_str(v));
+  }
+
+  bool operator==(const VectorTags& that) const {
+    return that.entries_ == entries_;
+  }
+
+  value_t at(value_t key) const {
+    auto it = std::find_if(entries_.rbegin(), entries_.rend(),
+    [key](const entry_t& entry) { return entry.first == key; });
+    if (it != entries_.rend()) {
+      return it->second;
+    }
+    return util::intern_str("");  // cannot throw exceptions on nodejs
+  }
+ private:
+  std::vector<entry_t> entries_;
+};
+
+template <typename T>
 static void add_tags(benchmark::State& state) {
   std::string prefix{"some.random.string.for.testing."};
   const char* value = "some.random.value.for.testing";
   for (auto _ : state) {
-    Tags<C> tags;
+    T tags;
     for (int i = 0; i < state.range(0); ++i) {
       tags.add((prefix + std::to_string(i)).c_str(), value);
     }
   }
 }
 
-template <typename C>
-static Tags<C> get_tags(int keys) {
+template <typename T>
+static T get_tags(int keys) {
   std::string prefix{"nf.random"};
   const char* value = "some.random.value.for.testing";
-  Tags<C> tags;
+  T tags;
   for (int i = 0; i < keys; ++i) {
     tags.add((prefix + std::to_string(i)).c_str(), value);
   }
@@ -63,41 +90,66 @@ static Tags<C> get_tags(int keys) {
 
 using UnorderedMap = std::unordered_map<util::StrRef, util::StrRef>;
 using OrderedMap = std::map<util::StrRef, util::StrRef>;
+using util::SmallTagMap;
 
 static void BM_TagsUnorderedMap(benchmark::State& state) {
-  add_tags<UnorderedMap>(state);
+  add_tags<Tags<UnorderedMap>>(state);
 }
-BENCHMARK(BM_TagsUnorderedMap)->RangeMultiplier(2)->Range(4, 32);
+BENCHMARK(BM_TagsUnorderedMap)->RangeMultiplier(2)->Range(2, 32);
 
 static void BM_TagsOrdered(benchmark::State& state) {
-  add_tags<OrderedMap>(state);
+  add_tags<Tags<OrderedMap>>(state);
 }
-BENCHMARK(BM_TagsOrdered)->RangeMultiplier(2)->Range(4, 32);
+BENCHMARK(BM_TagsOrdered)->RangeMultiplier(2)->Range(2, 32);
 
-template <typename C>
+static void BM_VectorTags(benchmark::State& state) {
+  add_tags<VectorTags>(state);
+}
+BENCHMARK(BM_VectorTags)->RangeMultiplier(2)->Range(2, 32);
+
+static void BM_SmallTags(benchmark::State& state) {
+  add_tags<SmallTagMap>(state);
+}
+BENCHMARK(BM_SmallTags)->RangeMultiplier(2)->Range(2, 32);
+
+template <typename T>
 static void do_tags_get(benchmark::State& state) {
-  Tags<C> tags = get_tags<C>(state.range(0));
+  auto non_existing = util::intern_str("does.not.exist");
+  T tags = get_tags<T>(state.range(0));
 
   for (auto _ : state) {
-    for (int i = 0; i < state.range(1); ++i) {
-      char buf[256];
-      snprintf(buf, sizeof buf, "nf.random%d", i);
+    int N = state.range(1);
+    for (int i = 0; i < N; ++i) {
+      int random_key = rand() % N;
+      char buf[32];
+      snprintf(buf, sizeof buf, "nf.random%d", random_key);
       auto ref = util::intern_str(buf);
       benchmark::DoNotOptimize(tags.at(ref));
+      benchmark::DoNotOptimize(tags.at(non_existing));
     }
   }
 }
 
 static void BM_TagsUnorderedGet(benchmark::State& state) {
-  do_tags_get<UnorderedMap>(state);
+  do_tags_get<Tags<UnorderedMap>>(state);
 }
 
 static void BM_TagsOrderedGet(benchmark::State& state) {
-  do_tags_get<OrderedMap>(state);
+  do_tags_get<Tags<OrderedMap>>(state);
 }
 
-BENCHMARK(BM_TagsUnorderedGet)->RangeMultiplier(2)->Ranges({{4, 32}, {8, 16}});
-BENCHMARK(BM_TagsOrderedGet)->RangeMultiplier(2)->Ranges({{4, 32}, {8, 16}});
+static void BM_VectorTagsGet(benchmark::State& state) {
+  do_tags_get<VectorTags>(state);
+}
+
+static void BM_SmallTagsGet(benchmark::State& state) {
+  do_tags_get<SmallTagMap>(state);
+}
+
+BENCHMARK(BM_TagsUnorderedGet)->RangeMultiplier(2)->Ranges({{8, 24}, {8, 16}});
+BENCHMARK(BM_TagsOrderedGet)->RangeMultiplier(2)->Ranges({{8, 24}, {8, 16}});
+BENCHMARK(BM_VectorTagsGet)->RangeMultiplier(2)->Ranges({{8, 24}, {8, 16}});
+BENCHMARK(BM_SmallTagsGet)->RangeMultiplier(2)->Ranges({{8, 24}, {8, 16}});
 
 }  //  namespace atlas
 BENCHMARK_MAIN();

--- a/interpreter/multiple_results.cc
+++ b/interpreter/multiple_results.cc
@@ -9,9 +9,9 @@ const OptionalString kNone{nullptr};
 
 OptionalString MultipleResults::get_value(const TagsValuePair& tagsValuePair,
                                           const util::StrRef k) {
-  auto it = tagsValuePair.tags.find(k);
-  if (it != tagsValuePair.tags.end()) {
-    return OptionalString{(*it).second.get()};
+  auto v = tagsValuePair.tags.at(k);
+  if (*v.get() != '\0') {
+    return OptionalString{v.get()};
   }
 
   return kNone;

--- a/interpreter/query.cc
+++ b/interpreter/query.cc
@@ -20,7 +20,7 @@ bool Query::IsRegex() const noexcept { return false; }
 HasKeyQuery::HasKeyQuery(std::string key) : AbstractKeyQuery(std::move(key)) {}
 
 bool HasKeyQuery::Matches(const meter::Tags& tags) const {
-  return tags.find(KeyRef()) != tags.end();
+  return tags.has(KeyRef());
 }
 
 std::ostream& HasKeyQuery::Dump(std::ostream& os) const {
@@ -33,11 +33,11 @@ AbstractKeyQuery::AbstractKeyQuery(std::string key) noexcept
 
 const OptionalString AbstractKeyQuery::getvalue(const meter::Tags& tags) const
     noexcept {
-  auto k = tags.find(KeyRef());
-  if (k == tags.end()) {
+  auto k = tags.at(KeyRef());
+  if (*k.get() == '\0') {
     return kNone;
   }
-  return OptionalString{k->second.get()};
+  return OptionalString{k.get()};
 }
 
 const std::string& AbstractKeyQuery::Key() const noexcept { return key_; }
@@ -185,8 +185,7 @@ std::ostream& operator<<(std::ostream& os, const RelOp& op) {
 }
 
 InQuery::InQuery(std::string key, std::unique_ptr<StringRefs> vs) noexcept
-    : AbstractKeyQuery(std::move(key)),
-      vs_(std::move(vs)) {}
+    : AbstractKeyQuery(std::move(key)), vs_(std::move(vs)) {}
 
 bool InQuery::Matches(const meter::Tags& tags) const {
   auto value = getvalue(tags);

--- a/meter/bucket_functions.cc
+++ b/meter/bucket_functions.cc
@@ -14,8 +14,7 @@ namespace {
 class Bucket {
  public:
   Bucket(std::string name, int64_t upper_boundary) noexcept
-      : name_{std::move(name)},
-        upper_boundary_{upper_boundary} {}
+      : name_{std::move(name)}, upper_boundary_{upper_boundary} {}
 
   std::string Name() const noexcept { return name_; }
   int64_t UpperBoundary() const noexcept { return upper_boundary_; }
@@ -29,8 +28,7 @@ using Buckets = std::vector<Bucket>;
 class BucketsFunction {
  public:
   BucketsFunction(Buckets&& buckets, std::string&& fallback) noexcept
-      : buckets_{buckets},
-        fallback_{fallback} {}
+      : buckets_{buckets}, fallback_{fallback} {}
 
   std::string operator()(int64_t amount) {
     for (const auto& b : buckets_) {
@@ -63,10 +61,8 @@ class ValueFormatter {
   ///     Factor conversion from value to unit for label.
   ///
   ValueFormatter(int64_t max, int width, std::string suffix,
-                 int64_t factor) noexcept : max_{max},
-                                            width_{width},
-                                            suffix_{std::move(suffix)},
-                                            factor_{factor} {}
+                 int64_t factor) noexcept
+      : max_{max}, width_{width}, suffix_{std::move(suffix)}, factor_{factor} {}
 
   /// Get the bucket label for the value v
   std::string GetLabel(int64_t v) const noexcept {

--- a/meter/manual_clock.h
+++ b/meter/manual_clock.h
@@ -8,8 +8,7 @@ namespace meter {
 class ManualClock : public Clock {
  public:
   ManualClock(int64_t wall = 0, int64_t monotonic = 0) noexcept
-      : wall_(wall),
-        monotonic_(monotonic) {}
+      : wall_(wall), monotonic_(monotonic) {}
 
   virtual int64_t WallTime() const noexcept override { return wall_.load(); }
 

--- a/meter/tag.h
+++ b/meter/tag.h
@@ -1,0 +1,22 @@
+#include "../util/intern.h"
+
+namespace atlas {
+namespace meter {
+
+struct Tag {
+  util::StrRef key;
+  util::StrRef value;
+
+  Tag() noexcept {}
+  Tag(util::StrRef k, util::StrRef v) noexcept : key{k}, value{v} {}
+
+  static Tag of(const char* k, const char* v) noexcept {
+    return Tag{util::intern_str(k), util::intern_str(v)};
+  }
+  static Tag of(const std::string& k, const std::string& v) noexcept {
+    return Tag{util::intern_str(k), util::intern_str(v)};
+  }
+};
+
+}  // namespace meter
+}  // namespace atlas

--- a/test/percentile_dist_summary_test.cc
+++ b/test/percentile_dist_summary_test.cc
@@ -39,7 +39,7 @@ TEST(PercentileDistributionSummary, HasProperStatistic) {
   auto statisticRef = intern_str("statistic");
   for (auto i = ms.begin(); i != ms.end(); ++i) {
     auto tags = (*i)->GetId()->GetTags();
-    if (tags.find(percentileRef) != tags.end()) {
+    if (tags.has(percentileRef)) {
       EXPECT_EQ(tags.at(statisticRef), percentileRef);
     }
   }

--- a/test/percentile_timer_test.cc
+++ b/test/percentile_timer_test.cc
@@ -38,7 +38,7 @@ TEST(PercentileTimer, HasProperStatistic) {
   auto statisticRef = intern_str("statistic");
   for (auto i = ms.begin(); i != ms.end(); ++i) {
     auto tags = (*i)->GetId()->GetTags();
-    if (tags.find(percentileRef) != tags.end()) {
+    if (tags.has(percentileRef)) {
       EXPECT_EQ(tags.at(statisticRef), percentileRef);
     }
   }

--- a/test/small_tag_map_test.cc
+++ b/test/small_tag_map_test.cc
@@ -1,0 +1,47 @@
+#include "../util/small_tag_map.h"
+#include <gtest/gtest.h>
+
+using atlas::util::SmallTagMap;
+
+TEST(SmallTagMap, Init) {
+  SmallTagMap map;
+  EXPECT_EQ(map.size(), 0);
+}
+
+TEST(SmallTagMap, Add) {
+  SmallTagMap map;
+  map.add("test", "value");
+  map.add("test", "value1");
+  map.add("test", "value2");
+  EXPECT_EQ(map.size(), 1);
+  char buf[32];
+  for (auto i = 0; i < 20; ++i) {
+    snprintf(buf, sizeof buf, "test%d", i);
+    map.add(buf, buf);
+    EXPECT_EQ(map.size(), i + 2);
+  }
+}
+
+TEST(SmallTagMap, Get) {
+  using atlas::util::intern_str;
+
+  SmallTagMap map;
+  auto empty = intern_str("");
+  auto test_ref = intern_str("test");
+  EXPECT_EQ(map.at(test_ref).get(), empty.get()) << "at on empty map";
+
+  map.add("test", "value");
+  EXPECT_EQ(map.at(test_ref).get(), intern_str("value").get()) << "simple get";
+
+  map.add("test", "value1");
+  map.add("test", "value2");
+  EXPECT_EQ(map.at(test_ref).get(), intern_str("value2").get()) << "simple get";
+
+  char buf[32];
+  for (auto i = 0; i < 20; ++i) {
+    snprintf(buf, sizeof buf, "test%d", i);
+    map.add(buf, buf);
+    auto buf_ref = intern_str(buf);
+    EXPECT_EQ(map.at(buf_ref).get(), buf_ref.get());
+  }
+}

--- a/test/strings_test.cc
+++ b/test/strings_test.cc
@@ -9,8 +9,8 @@ static atlas::util::StrRef to_ref(const char* s) { return intern_str(s); }
 TEST(ExpandVars, InPlace) {
   string tmpl = "foo $bar ${baz}";
   auto replacer = [](const string& var) -> string {
-    EXPECT_TRUE(var == "bar" || var == "baz") << "Unexpected '" << var
-                                              << "' variable";
+    EXPECT_TRUE(var == "bar" || var == "baz")
+        << "Unexpected '" << var << "' variable";
     if (var == "bar") {
       return "BAR";
     }
@@ -26,8 +26,8 @@ TEST(ExpandVars, InPlace) {
 TEST(ExpandVars, Words) {
   string tmpl = "$baz.iep$bar.$baz.netflix";
   auto replacer = [](const string& var) -> string {
-    EXPECT_TRUE(var == "bar" || var == "baz") << "Unexpected '" << var
-                                              << "' variable";
+    EXPECT_TRUE(var == "bar" || var == "baz")
+        << "Unexpected '" << var << "' variable";
     if (var == "bar") {
       return "BAR";
     }
@@ -114,8 +114,8 @@ TEST(Strings, ExpandVarsUrl) {
                                             {"NETFLIX_ENVIRONMENT", "test"},
                                             {"EC2_REGION", "us-east-1"}};
   auto replacer = [&env](const string& var) -> string {
-    EXPECT_TRUE(env.find(var) != env.end()) << "Unknown variable '" << var
-                                            << "'";
+    EXPECT_TRUE(env.find(var) != env.end())
+        << "Unknown variable '" << var << "'";
     return env[var];
   };
 

--- a/util/config_manager.cc
+++ b/util/config_manager.cc
@@ -185,9 +185,9 @@ std::unique_ptr<Config> DefaultConfig(bool notify) noexcept {
   return std::make_unique<Config>(
       disabled_file, std::string(kEvaluateUrl), std::string(kSubscriptionsUrl),
       std::string(kPublishUrl), kValidateMetrics, std::string(kCheckClusterUrl),
-      notify, // whether to notify alert-server about on-instance alert support
-      kPublishConfig, kRefresherMillis, kConnectTimeout,
-      kReadTimeout, kBatchSize,
+      notify,  // whether to notify alert-server about on-instance alert support
+      kPublishConfig, kRefresherMillis, kConnectTimeout, kReadTimeout,
+      kBatchSize,
       // do not run on dev env
       false,
       // enable main but not subscriptions yet (need clusters in main account)

--- a/util/intern.h
+++ b/util/intern.h
@@ -29,7 +29,9 @@ namespace std {
 template <>
 struct hash<atlas::util::StrRef> {
   size_t operator()(const atlas::util::StrRef& ref) const {
-    return reinterpret_cast<size_t>(ref.data);
+    auto pointer_value = reinterpret_cast<uint64_t>(ref.data);
+    // get rid of lower bits since the pointer will usually be 16-byte aligned
+    return pointer_value >> 4;
   }
 };
 }

--- a/util/small_tag_map.h
+++ b/util/small_tag_map.h
@@ -1,0 +1,256 @@
+#include "../meter/tag.h"
+#include "logger.h"
+
+#pragma once
+
+namespace atlas {
+namespace util {
+
+namespace detail {
+static const size_t constexpr prime_list[] = {3lu, 7lu, 17lu, 29lu, 37lu};
+static const util::StrRef kNotFound = util::intern_str("");
+
+struct prime_number_hash_policy {
+  static size_t mod3(size_t hash) { return hash % 3lu; }
+  static size_t mod7(size_t hash) { return hash % 7lu; }
+  static size_t mod17(size_t hash) { return hash % 17lu; }
+  static size_t mod29(size_t hash) { return hash % 29lu; }
+  static size_t mod37(size_t hash) { return hash % 37lu; }
+
+  size_t index_for_hash(size_t hash) const {
+    static constexpr size_t (*const mod_functions[])(size_t) = {
+        &mod3, &mod7, &mod17, &mod29, &mod37};
+    return mod_functions[prime_index](hash);
+  }
+
+  size_t next_size_over(size_t* size) const {
+    auto n = *size;
+    auto idx = prime_index + 1;
+    while (prime_list[idx] < n) {
+      ++idx;
+    }
+    *size = prime_list[idx];
+    return idx;
+  }
+
+  void commit(size_t new_prime_index) { prime_index = new_prime_index; }
+
+  template <typename T>
+  size_t pos_for_key(T t) const {
+    return index_for_hash(std::hash<T>()(t));
+  }
+
+  size_t num_buckets() const { return prime_list[prime_index]; }
+
+  size_t prime_index = 0;
+};
+
+static constexpr size_t kMaxTags = 32u;
+}
+
+class SmallTagMap : private detail::prime_number_hash_policy {
+  using value_type = std::pair<util::StrRef, util::StrRef>;
+
+ public:
+  SmallTagMap() noexcept { init(); }
+
+  SmallTagMap(const SmallTagMap& other) noexcept {
+    prime_index = other.prime_index;
+    actual_size_ = other.actual_size_;
+    auto N = num_buckets();
+    entries_.reset(new value_type[N]);
+    for (auto i = 0u; i < N; ++i) {
+      entries_[i] = other.entries_[i];
+    }
+  }
+
+  SmallTagMap(SmallTagMap&& other) noexcept {
+    prime_index = other.prime_index;
+    entries_ = std::move(other.entries_);
+    actual_size_ = other.actual_size_;
+  }
+
+  SmallTagMap(std::initializer_list<meter::Tag> vs) {
+    init();
+    for (const auto& tag : vs) {
+      add(tag.key, tag.value);
+    }
+  }
+
+  void add(const char* k, const char* v) noexcept {
+    add(util::intern_str(k), util::intern_str(v));
+  }
+
+  void add(util::StrRef k_ref, util::StrRef v_ref) noexcept {
+    const auto pos = pos_for_key(k_ref);
+    auto i = pos;
+    auto ki = entries_[i].first;
+    while (ki.get() != nullptr && ki.get() != k_ref.get()) {
+      i = index_for_hash(i + 1);  // avoid expensive mod variable operation
+      if (i == pos) {
+        if (actual_size_ >= detail::kMaxTags) {
+          Logger()->error("cannot add tag({},{}) - Maximum of {} tags reached.",
+                          k_ref.get(), v_ref.get(), detail::kMaxTags);
+          return;
+        }
+        resize(actual_size_ + 1);
+        add(k_ref, v_ref);
+        return;
+      }
+      ki = entries_[i].first;
+    }
+
+    if (ki.get() != nullptr) {
+      entries_[i].second = v_ref;
+    } else {
+      if (entries_[i].first.get() != nullptr) {
+        throw std::runtime_error("position has already been filled");
+      }
+      entries_[i].first = k_ref;
+      entries_[i].second = v_ref;
+      ++actual_size_;
+    }
+  }
+
+  void add_all(const SmallTagMap& other) {
+    auto other_buckets = other.num_buckets();
+    for (auto i = 0u; i < other_buckets; ++i) {
+      const auto& ki = other.entries_[i].first;
+      if (ki.get() != nullptr) {
+        add(ki, other.entries_[i].second);
+      }
+    }
+  }
+
+  util::StrRef at(util::StrRef key) const noexcept {
+    auto pos = pos_for_key(key);
+    auto i = pos;
+    auto ki = entries_[i].first;
+    while (ki.get() != nullptr && ki.get() != key.get()) {
+      i = index_for_hash(i + 1);
+      if (i == pos) {
+        return detail::kNotFound;
+      }
+      ki = entries_[i].first;
+    }
+    return ki.get() == nullptr ? detail::kNotFound : entries_[i].second;
+  }
+
+  bool has(util::StrRef key) const noexcept {
+    return at(key).get() != detail::kNotFound.get();
+  }
+
+  size_t size() const noexcept { return actual_size_; }
+
+  size_t hash() const noexcept {
+    auto res = 0u;
+    auto N = num_buckets();
+    for (auto i = 0u; i < N; ++i) {
+      const auto& entry = entries_[i];
+      if (entry.first.get() != nullptr) {
+        res += (std::hash<util::StrRef>()(entry.first) << 1) ^
+               std::hash<util::StrRef>()(entry.second);
+      }
+    }
+    return res;
+  }
+
+  bool operator==(const SmallTagMap& other) const noexcept {
+    if (other.size() != size()) return false;
+
+    const auto N = num_buckets();
+    for (auto i = 0u; i < N; ++i) {
+      const auto& entry = entries_[i];
+      if (entry.first.get() != nullptr) {
+        bool eq = entry.second.get() == other.at(entry.first).get();
+        if (!eq) return false;
+      }
+    }
+    return true;
+  }
+
+  template <typename ValueType>
+  struct templated_iterator {
+    templated_iterator(const value_type* entries, size_t index,
+                       size_t num_buckets)
+        : current_idx{index}, entries_(entries), num_buckets_(num_buckets) {}
+
+    friend bool operator==(const templated_iterator& lhs,
+                           const templated_iterator& rhs) {
+      return lhs.current_idx == rhs.current_idx;
+    }
+
+    friend bool operator!=(const templated_iterator& lhs,
+                           const templated_iterator& rhs) {
+      return lhs.current_idx != rhs.current_idx;
+    }
+
+    ValueType& operator*() const { return entries_[current_idx]; }
+
+    templated_iterator& operator++() {
+      do {
+        ++current_idx;
+      } while (current_idx < num_buckets_ && is_empty(current_idx));
+      return *this;
+    }
+
+   private:
+    size_t current_idx;
+    const value_type* entries_;
+    size_t num_buckets_;
+
+    bool is_empty(size_t idx) { return entries_[idx].first.get() == nullptr; }
+  };
+
+  using const_iterator = templated_iterator<const value_type>;
+
+  const_iterator begin() const noexcept {
+    auto idx = 0u;
+    auto N = num_buckets();
+    while (idx < N) {
+      if (entries_[idx].first.get() != nullptr) {
+        break;
+      }
+      ++idx;
+    }
+
+    return const_iterator(entries_.get(), idx, N);
+  }
+
+  const_iterator end() const noexcept {
+    size_t N = num_buckets();
+    return const_iterator(entries_.get(), N, N);
+  }
+
+ private:
+  std::unique_ptr<value_type[]> entries_{};
+  size_t actual_size_ = 0u;
+
+  void init() {
+    size_t buckets = 0;
+    auto idx = next_size_over(&buckets);
+    commit(idx);
+    entries_.reset(new value_type[buckets]);
+  }
+
+  void resize(size_t new_desired_size) noexcept {
+    auto prev_entries = std::move(entries_);
+    auto prev_buckets = num_buckets();
+
+    auto new_bucket_count = new_desired_size;
+    auto new_idx = next_size_over(&new_bucket_count);
+    entries_.reset(new value_type[new_bucket_count]);
+    commit(new_idx);
+
+    actual_size_ = 0;
+    for (auto i = 0u; i < prev_buckets; ++i) {
+      const auto& entry = prev_entries[i];
+      if (entry.first.get() != nullptr) {
+        add(entry.first, entry.second);
+      }
+    }
+  }
+};
+
+}  // namespace util
+}  // namespace atlas

--- a/util/string_pool.cc
+++ b/util/string_pool.cc
@@ -3,8 +3,8 @@
 namespace atlas {
 namespace util {
 
-StringPool& the_str_pool() {
-  static StringPool* the_pool = new StringPool();
+StringPool& the_str_pool() noexcept {
+  static auto* the_pool = new StringPool();
   return *the_pool;
 }
 

--- a/util/string_pool.h
+++ b/util/string_pool.h
@@ -42,6 +42,6 @@ class StringPool {
   std::mutex mutex;
 };
 
-StringPool& the_str_pool();
+StringPool& the_str_pool() noexcept;
 }
 }


### PR DESCRIPTION
A custom small hash map is significantly faster than
the standard unordered_map and map.

```
Run on (8 X 2700 MHz CPU s)
2017-11-15 13:58:14
-----------------------------------------------------------------
Benchmark                          Time           CPU Iterations
-----------------------------------------------------------------
BM_TagsUnorderedMap/2           1129 ns       1127 ns     586127
BM_TagsUnorderedMap/4           2313 ns       2306 ns     295021
BM_TagsUnorderedMap/8           4716 ns       4694 ns     144693
BM_TagsUnorderedMap/16          9258 ns       9177 ns      71353
BM_TagsUnorderedMap/32         18544 ns      18501 ns      38493
BM_TagsOrdered/2                 994 ns        992 ns     667595
BM_TagsOrdered/4                2022 ns       2017 ns     339996
BM_TagsOrdered/8                3952 ns       3949 ns     166895
BM_TagsOrdered/16               8248 ns       8240 ns      80462
BM_TagsOrdered/32              17419 ns      17393 ns      39387
BM_VectorTags/2                 1065 ns       1063 ns     668392
BM_VectorTags/4                 1907 ns       1904 ns     368417
BM_VectorTags/8                 3416 ns       3411 ns     204508
BM_VectorTags/16                6435 ns       6423 ns     109900
BM_VectorTags/32               12081 ns      12058 ns      54812
BM_SmallTags/2                   896 ns        894 ns     786058
BM_SmallTags/4                  1518 ns       1516 ns     451330
BM_SmallTags/8                  3344 ns       3339 ns     209345
BM_SmallTags/16                 6287 ns       6275 ns     107936
BM_SmallTags/32                13567 ns      13542 ns      53926
BM_TagsUnorderedGet/8/8         2110 ns       2106 ns     331681
BM_TagsUnorderedGet/16/8        2091 ns       2088 ns     326962
BM_TagsUnorderedGet/24/8        1921 ns       1918 ns     348925
BM_TagsUnorderedGet/8/16        4982 ns       4974 ns     142804
BM_TagsUnorderedGet/16/16       4300 ns       4294 ns     163562
BM_TagsUnorderedGet/24/16       3965 ns       3959 ns     176811
BM_TagsOrderedGet/8/8           2121 ns       2117 ns     319062
BM_TagsOrderedGet/16/8          2169 ns       2164 ns     335175
BM_TagsOrderedGet/24/8          2280 ns       2271 ns     304324
BM_TagsOrderedGet/8/16          4746 ns       4735 ns     143837
BM_TagsOrderedGet/16/16         4592 ns       4582 ns     154675
BM_TagsOrderedGet/24/16         4503 ns       4497 ns     152870
BM_VectorTagsGet/8/8            1925 ns       1921 ns     389389
BM_VectorTagsGet/16/8           1957 ns       1954 ns     354755
BM_VectorTagsGet/24/8           2017 ns       2015 ns     337704
BM_VectorTagsGet/8/16           4203 ns       4196 ns     162451
BM_VectorTagsGet/16/16          3987 ns       3966 ns     173894
BM_VectorTagsGet/24/16          4163 ns       4151 ns     171853
BM_SmallTagsGet/8/8             1408 ns       1406 ns     529737
BM_SmallTagsGet/16/8            1704 ns       1695 ns     422496
BM_SmallTagsGet/24/8            1455 ns       1451 ns     501336
BM_SmallTagsGet/8/16            3026 ns       3016 ns     218596
BM_SmallTagsGet/16/16           3542 ns       3536 ns     199969
BM_SmallTagsGet/24/16           2984 ns       2979 ns     229669
```