### PR TITLE
Make number and size of log files configurable

### DIFF
--- a/atlas_client.cc
+++ b/atlas_client.cc
@@ -118,6 +118,10 @@ void SetLoggingDirs(const std::vector<std::string>& dirs) {
   atlas::util::SetLoggingDirs(dirs);
 }
 
+void SetLogSizes(size_t max_size, size_t max_files) {
+  atlas::util::SetLogSizes({max_size, max_files});
+}
+
 void UseConsoleLogger(int level) { atlas::util::UseConsoleLogger(level); }
 
 void SetNotifyAlertServer(bool notify) {

--- a/atlas_client.h
+++ b/atlas_client.h
@@ -12,6 +12,7 @@ void AddCommonTag(const char* key, const char* value);
 util::Config GetConfig();
 void PushMeasurements(const atlas::meter::Measurements& measurements);
 void SetLoggingDirs(const std::vector<std::string>& dirs);
+void SetLogSizes(size_t max_files, size_t max_size);
 void UseConsoleLogger(int level);
 void SetNotifyAlertServer(bool notify);
 }  // namespace atlas

--- a/resources/atlas-config-reference.json
+++ b/resources/atlas-config-reference.json
@@ -1,5 +1,7 @@
 {
   "logVerbosity": 2,
+  "logMaxSize": 1048576,
+  "logMaxFiles": 8,
   "evaluateUrl": "http://atlas-lwcapi-iep.$EC2_REGION.iep$NETFLIX_ENVIRONMENT.netflix.net/lwc/api/v1/evaluate",
   "subscriptionsUrl": "http://atlas-lwcapi-iep.$EC2_REGION.iep$NETFLIX_ENVIRONMENT.netflix.net/lwc/api/v1/$NETFLIX_AUTO_SCALE_GROUP",
   "publishUrl": "http://atlas-pub-$EC2_OWNER_ID.$EC2_REGION.$NETFLIX_ACCOUNT.netflix.net/api/v1/publish-fast",

--- a/util/config.cc
+++ b/util/config.cc
@@ -17,8 +17,8 @@ Config::Config(const std::string& disabled_file,
                int64_t subscription_refresh, int connect_timeout,
                int read_timeout, int batch_size, bool force_start,
                bool enable_main, bool enable_subscriptions, bool dump_metrics,
-               bool dump_subscriptions, int log_verbosity,
-               meter::Tags common_tags) noexcept
+               bool dump_subscriptions, int log_verbosity, size_t log_max_size,
+               size_t log_max_files, meter::Tags common_tags) noexcept
     : disabled_file_watcher_(disabled_file),
       evaluate_endpoint_(ExpandEnvVars(evaluate_endpoint)),
       subscriptions_endpoint_(ExpandEnvVars(subscriptions_endpoint)),
@@ -37,6 +37,8 @@ Config::Config(const std::string& disabled_file,
       dump_metrics_(dump_metrics),
       dump_subscriptions_(dump_subscriptions),
       log_verbosity_(log_verbosity),
+      log_max_size_(log_max_size),
+      log_max_files_(log_max_files),
       common_tags_(std::move(common_tags)) {}
 
 std::string Config::LoggingDirectory() const noexcept {

--- a/util/config.h
+++ b/util/config.h
@@ -23,6 +23,7 @@ class Config {
          int connect_timeout, int read_timeout, int batch_size,
          bool force_start, bool enable_main, bool enable_subscriptions,
          bool dump_metrics, bool dump_subscriptions, int log_verbosity,
+         size_t log_max_size, size_t log_max_files,
          meter::Tags common_tags) noexcept;
 
   std::string EvalEndpoint() const noexcept { return evaluate_endpoint_; }
@@ -47,6 +48,8 @@ class Config {
     return publish_config_;
   }
   int LogVerbosity() const noexcept { return log_verbosity_; }
+  size_t LogMaxSize() const noexcept { return log_max_size_; }
+  size_t LogMaxFiles() const noexcept { return log_max_files_; }
   meter::Tags CommonTags() const noexcept { return common_tags_; }
   void AddCommonTags(const meter::Tags& extra_tags) noexcept {
     common_tags_.add_all(extra_tags);
@@ -74,6 +77,8 @@ class Config {
   bool dump_metrics_;
   bool dump_subscriptions_;
   int log_verbosity_;
+  size_t log_max_size_;
+  size_t log_max_files_;
   meter::Tags common_tags_;
 };
 

--- a/util/logger.cc
+++ b/util/logger.cc
@@ -12,6 +12,7 @@ static std::vector<std::string> logging_directories = {"/logs/atlasd",
                                                        "./logs"};
 
 static std::string current_logging_directory;
+static LogNumSize current_log_num_size{1024u * 1024u, 8};
 
 static bool is_writable_dir(const std::string& dir) {
   struct stat dir_stat;
@@ -67,7 +68,8 @@ static void initialize_logger(const std::string& log_dir) {
     });
     auto logger = spdlog::create<spdlog::sinks::rotating_file_sink_mt>(
         kMainLogger, join_path(log_dir, "atlasclient"),
-        SPDLOG_FILENAME_T("log"), 1 * 1024 * 1024, 8);
+        SPDLOG_FILENAME_T("log"), current_log_num_size.max_size,
+        current_log_num_size.max_files);
     current_logging_directory = log_dir;
     logger->flush_on(spdlog::level::info);
   } else {
@@ -130,6 +132,19 @@ void UseConsoleLogger(int level) noexcept {
   logger = spdlog::stdout_color_mt(kMainLogger);
   logger->set_level(level_from_int(level));
   current_logging_directory = "";
+}
+
+LogNumSize GetLogSizes() noexcept { return current_log_num_size; }
+
+void SetLogSizes(const LogNumSize& log_num_size) noexcept {
+  std::lock_guard<std::mutex> lock(logger_mutex);
+  auto logger = spdlog::get(kMainLogger);
+  if (logger) {
+    spdlog::drop(kMainLogger);
+  }
+
+  current_log_num_size = log_num_size;
+  initialize();
 }
 
 std::string GetLoggingDir() noexcept { return current_logging_directory; }

--- a/util/logger.h
+++ b/util/logger.h
@@ -10,6 +10,14 @@ std::shared_ptr<spdlog::logger> Logger() noexcept;
 void UseConsoleLogger(int level) noexcept;
 void SetLoggingLevel(int level) noexcept;
 void SetLoggingDirs(const std::vector<std::string>& dirs) noexcept;
+
+struct LogNumSize {
+  size_t max_size;
+  size_t max_files;
+};
+
+void SetLogSizes(const LogNumSize& log_num_size) noexcept;
+LogNumSize GetLogSizes() noexcept;
 std::string GetLoggingDir() noexcept;
 
 }  // namespace util


### PR DESCRIPTION
Previously we were hardcoding the log size configuration to 8 x 1MB log
files, but some applications that handle millions of measurements want
to run to with verbose logs for debugging purposes, and need to tweak
the defaults to increase the values significantly.