### PR TITLE
Remove logger from SmallTagMap public API

### DIFF
--- a/test/small_tag_map_test.cc
+++ b/test/small_tag_map_test.cc
@@ -45,3 +45,21 @@ TEST(SmallTagMap, Get) {
     EXPECT_EQ(map.at(buf_ref).get(), buf_ref.get());
   }
 }
+
+TEST(SmallTagMap, AddAll) {
+  auto map1 = SmallTagMap{{"k1", "v1"}, {"k2", "v2"}};
+  auto map2 = SmallTagMap{{"k3", "v1"}, {"k4", "v2"}};
+  auto expected = SmallTagMap{{"k1", "v1"}, {"k2", "v2"}, {"k3", "v1"}, {"k4", "v2"}};
+
+  map1.add_all(map2);
+  EXPECT_EQ(map1, expected);
+}
+
+TEST(SmallTagMap, AddAllOverrides) {
+  auto map1 = SmallTagMap{{"k1", "v1"},{"k2","v2"}};
+  auto map2 = SmallTagMap{{"k3", "v3"},{"k1","v4"}};
+  auto expected = SmallTagMap{{"k1","v4"},{"k2", "v2"},{"k3", "v3"}};
+
+  map1.add_all(map2);
+  EXPECT_EQ(map1, expected);
+}

--- a/util/intern.h
+++ b/util/intern.h
@@ -12,7 +12,10 @@ class StrRef {
  public:
   StrRef() = default;
   bool operator==(const StrRef& rhs) const { return data == rhs.data; }
+  bool operator!=(const StrRef& rhs) const { return data != rhs.data; }
   const char* get() const { return data; }
+  bool empty() const { return data == nullptr; }
+  bool valid() const { return data != nullptr; }
 
  private:
   const char* data = nullptr;

--- a/util/small_tag_map.cc
+++ b/util/small_tag_map.cc
@@ -1,0 +1,97 @@
+#include "small_tag_map.h"
+#include "logger.h"
+
+namespace atlas {
+namespace util {
+
+void SmallTagMap::add(util::StrRef k_ref, util::StrRef v_ref) noexcept {
+  const auto pos = pos_for_key(k_ref);
+  auto i = pos;
+  auto ki = entries_[i].first;
+  while (ki.get() != nullptr && ki.get() != k_ref.get()) {
+    i = index_for_hash(i + 1);  // avoid expensive mod variable operation
+    if (i == pos) {
+      if (actual_size_ >= detail::kMaxTags) {
+        Logger()->error("cannot add tag({},{}) - Maximum of {} tags reached.",
+                        k_ref.get(), v_ref.get(), detail::kMaxTags);
+        return;
+      }
+      resize(actual_size_ + 1);
+      add(k_ref, v_ref);
+      return;
+    }
+    ki = entries_[i].first;
+  }
+
+  if (ki.get() != nullptr) {
+    entries_[i].second = v_ref;
+  } else {
+    if (entries_[i].first.valid()) {
+      throw std::runtime_error("position has already been filled");
+    }
+    entries_[i].first = k_ref;
+    entries_[i].second = v_ref;
+    ++actual_size_;
+  }
+}
+
+util::StrRef SmallTagMap::at(util::StrRef key) const noexcept {
+  auto pos = pos_for_key(key);
+  auto i = pos;
+  auto ki = entries_[i].first;
+  while (ki.get() != nullptr && ki.get() != key.get()) {
+    i = index_for_hash(i + 1);
+    if (i == pos) {
+      return detail::kNotFound;
+    }
+    ki = entries_[i].first;
+  }
+  return ki.get() == nullptr ? detail::kNotFound : entries_[i].second;
+}
+
+size_t SmallTagMap::hash() const noexcept {
+  auto res = 0u;
+  auto N = num_buckets();
+  for (auto i = 0u; i < N; ++i) {
+    const auto& entry = entries_[i];
+    if (entry.first.valid()) {
+      res += (std::hash<util::StrRef>()(entry.first) << 1) ^
+             std::hash<util::StrRef>()(entry.second);
+    }
+  }
+  return res;
+}
+
+bool SmallTagMap::operator==(const SmallTagMap& other) const noexcept {
+  if (other.size() != size()) return false;
+
+  const auto N = num_buckets();
+  for (auto i = 0u; i < N; ++i) {
+    const auto& entry = entries_[i];
+    if (entry.first.valid()) {
+      bool eq = entry.second == other.at(entry.first);
+      if (!eq) return false;
+    }
+  }
+  return true;
+}
+void SmallTagMap::resize(size_t new_desired_size) noexcept {
+  auto prev_entries = std::move(entries_);
+  auto prev_buckets = num_buckets();
+
+  auto new_bucket_count = new_desired_size;
+  auto new_idx = next_size_over(&new_bucket_count);
+  entries_.reset(new value_type[new_bucket_count]);
+  commit(new_idx);
+
+  actual_size_ = 0;
+  for (auto i = 0u; i < prev_buckets; ++i) {
+    const auto& entry = prev_entries[i];
+    if (entry.first.valid()) {
+      add(entry.first, entry.second);
+    }
+  }
+}
+
+}  // namespace util
+}  // namespace atlas

--- a/util/small_tag_map.h
+++ b/util/small_tag_map.h
@@ -1,5 +1,4 @@
 #include "../meter/tag.h"
-#include "logger.h"
 
 #pragma once
 
@@ -77,40 +76,18 @@ class SmallTagMap : private detail::prime_number_hash_policy {
     }
   }
 
+  SmallTagMap(std::initializer_list<std::pair<const char*, const char*>> vs) {
+    init();
+    for (const auto& tag : vs) {
+      add(tag.first, tag.second);
+    }
+  }
+
   void add(const char* k, const char* v) noexcept {
     add(util::intern_str(k), util::intern_str(v));
   }
 
-  void add(util::StrRef k_ref, util::StrRef v_ref) noexcept {
-    const auto pos = pos_for_key(k_ref);
-    auto i = pos;
-    auto ki = entries_[i].first;
-    while (ki.get() != nullptr && ki.get() != k_ref.get()) {
-      i = index_for_hash(i + 1);  // avoid expensive mod variable operation
-      if (i == pos) {
-        if (actual_size_ >= detail::kMaxTags) {
-          Logger()->error("cannot add tag({},{}) - Maximum of {} tags reached.",
-                          k_ref.get(), v_ref.get(), detail::kMaxTags);
-          return;
-        }
-        resize(actual_size_ + 1);
-        add(k_ref, v_ref);
-        return;
-      }
-      ki = entries_[i].first;
-    }
-
-    if (ki.get() != nullptr) {
-      entries_[i].second = v_ref;
-    } else {
-      if (entries_[i].first.get() != nullptr) {
-        throw std::runtime_error("position has already been filled");
-      }
-      entries_[i].first = k_ref;
-      entries_[i].second = v_ref;
-      ++actual_size_;
-    }
-  }
+  void add(util::StrRef k_ref, util::StrRef v_ref) noexcept;
 
   void add_all(const SmallTagMap& other) {
     auto other_buckets = other.num_buckets();
@@ -122,52 +99,17 @@ class SmallTagMap : private detail::prime_number_hash_policy {
     }
   }
 
-  util::StrRef at(util::StrRef key) const noexcept {
-    auto pos = pos_for_key(key);
-    auto i = pos;
-    auto ki = entries_[i].first;
-    while (ki.get() != nullptr && ki.get() != key.get()) {
-      i = index_for_hash(i + 1);
-      if (i == pos) {
-        return detail::kNotFound;
-      }
-      ki = entries_[i].first;
-    }
-    return ki.get() == nullptr ? detail::kNotFound : entries_[i].second;
-  }
+  util::StrRef at(util::StrRef key) const noexcept;
 
   bool has(util::StrRef key) const noexcept {
-    return at(key).get() != detail::kNotFound.get();
+    return at(key) != detail::kNotFound;
   }
 
   size_t size() const noexcept { return actual_size_; }
 
-  size_t hash() const noexcept {
-    auto res = 0u;
-    auto N = num_buckets();
-    for (auto i = 0u; i < N; ++i) {
-      const auto& entry = entries_[i];
-      if (entry.first.get() != nullptr) {
-        res += (std::hash<util::StrRef>()(entry.first) << 1) ^
-               std::hash<util::StrRef>()(entry.second);
-      }
-    }
-    return res;
-  }
+  size_t hash() const noexcept;
 
-  bool operator==(const SmallTagMap& other) const noexcept {
-    if (other.size() != size()) return false;
-
-    const auto N = num_buckets();
-    for (auto i = 0u; i < N; ++i) {
-      const auto& entry = entries_[i];
-      if (entry.first.get() != nullptr) {
-        bool eq = entry.second.get() == other.at(entry.first).get();
-        if (!eq) return false;
-      }
-    }
-    return true;
-  }
+  bool operator==(const SmallTagMap& other) const noexcept;
 
   template <typename ValueType>
   struct templated_iterator {
@@ -199,7 +141,7 @@ class SmallTagMap : private detail::prime_number_hash_policy {
     const value_type* entries_;
     size_t num_buckets_;
 
-    bool is_empty(size_t idx) { return entries_[idx].first.get() == nullptr; }
+    bool is_empty(size_t idx) { return entries_[idx].first.empty(); }
   };
 
   using const_iterator = templated_iterator<const value_type>;
@@ -208,7 +150,7 @@ class SmallTagMap : private detail::prime_number_hash_policy {
     auto idx = 0u;
     auto N = num_buckets();
     while (idx < N) {
-      if (entries_[idx].first.get() != nullptr) {
+      if (entries_[idx].first.valid()) {
         break;
       }
       ++idx;
@@ -233,23 +175,7 @@ class SmallTagMap : private detail::prime_number_hash_policy {
     entries_.reset(new value_type[buckets]);
   }
 
-  void resize(size_t new_desired_size) noexcept {
-    auto prev_entries = std::move(entries_);
-    auto prev_buckets = num_buckets();
-
-    auto new_bucket_count = new_desired_size;
-    auto new_idx = next_size_over(&new_bucket_count);
-    entries_.reset(new value_type[new_bucket_count]);
-    commit(new_idx);
-
-    actual_size_ = 0;
-    for (auto i = 0u; i < prev_buckets; ++i) {
-      const auto& entry = prev_entries[i];
-      if (entry.first.get() != nullptr) {
-        add(entry.first, entry.second);
-      }
-    }
-  }
+  void resize(size_t new_desired_size) noexcept;
 };
 
 }  // namespace util


### PR DESCRIPTION
Refactor `SmallTagMap` to remove the dependency on the logger
implementation from the public API.

As part of the refactor add a couple of tests, and some helper methods
to `StrRef` to make it easier to use.