### PR TITLE
Validate using StrRefs

### DIFF
--- a/util/intern.h
+++ b/util/intern.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <cstring>
 
 namespace atlas {
 namespace util {
@@ -16,6 +17,7 @@ class StrRef {
   const char* get() const { return data; }
   bool empty() const { return data == nullptr; }
   bool valid() const { return data != nullptr; }
+  size_t length() const { return std::strlen(data); }
 
  private:
   const char* data = nullptr;

--- a/util/strings.h
+++ b/util/strings.h
@@ -45,9 +45,8 @@ StrRef EncodeValueForKey(StrRef value, StrRef key) noexcept;
 
 std::string join_path(const std::string& dir, const char* file_name) noexcept;
 
-inline bool StartsWith(const std::string& s,
-                       const std::string& prefix) noexcept {
-  return strncmp(s.c_str(), prefix.c_str(), prefix.size()) == 0;
+inline bool StartsWith(StrRef ref, const char* prefix) noexcept {
+  return strncmp(ref.get(), prefix, strlen(prefix)) == 0;
 }
 
 bool IStartsWith(const std::string& s, const std::string& prefix) noexcept;


### PR DESCRIPTION
Instead of instantiating strings for each key/value pair, use the
underlying `StrRef`s directly.