### PR TITLE
Use a vector for drop-tags instead of a hashmap

### DIFF
--- a/interpreter/keep_drop_tags.cc
+++ b/interpreter/keep_drop_tags.cc
@@ -3,8 +3,6 @@
 #include "../meter/measurement.h"
 #include "../util/dump.h"
 #include <algorithm>
-#include <unordered_set>
-#include <iostream>
 
 namespace atlas {
 namespace interpreter {
@@ -26,12 +24,11 @@ KeepOrDropTags::KeepOrDropTags(const List& keys,
 
 using StringRefs = std::vector<StrRef>;
 static StringRefs drop_keys(const meter::Tags& tags, const StringRefs& keys) {
-  std::unordered_set<StrRef> keys_set(keys.begin(), keys.end());
   StringRefs res{kNameRef};
 
   // add all tag keys that are not in the set of keys to be dropped
   for (const auto& tag : tags) {
-    if (keys_set.find(tag.first) == end(keys_set)) {
+    if (tag.first != kNameRef && std::find(keys.begin(), keys.end(), tag.first) == keys.end()) {
       res.push_back(tag.first);
     }
   }

--- a/interpreter/word.h
+++ b/interpreter/word.h
@@ -8,6 +8,7 @@ namespace interpreter {
 class Word {
  public:
   virtual OptionalString Execute(Context* context) = 0;
+  virtual ~Word() = default;
 };
 }
 }

--- a/test/interpreter_test.cc
+++ b/test/interpreter_test.cc
@@ -203,7 +203,7 @@ TEST(Interpreter, KeepTags) {
 }
 
 TEST(Interpreter, DropTags) {
-  auto context = exec("name,name1,:eq,k2,w1,:eq,:and,:count,(,k2,),:drop-tags");
+  auto context = exec("name,name1,:eq,k2,w1,:eq,:and,:count,(,k2,does.not.exist.tag,),:drop-tags");
   ASSERT_EQ(1, context->StackSize());
 
   auto expr = context->PopExpression();


### PR DESCRIPTION
Usually the number of tags to be dropped will be very small and using a
simple vector of StrRefs will be faster.

Adds a default virtual destructor to the Word interface. clang-6 was
complaining about it.