### PR TITLE
Rename StrRef empty to is_null for clarity reasons

### DIFF
--- a/meter/validation.cc
+++ b/meter/validation.cc
@@ -47,7 +47,7 @@ static bool is_user_key_invalid(util::StrRef k) noexcept {
   return false;
 }
 
-bool empty_or_null(util::StrRef r) { return r.empty() || r.length() == 0; }
+bool empty_or_null(util::StrRef r) { return r.is_null() || r.length() == 0; }
 
 bool IsValid(const Tags& tags) noexcept {
   std::string err_msg;

--- a/util/intern.h
+++ b/util/intern.h
@@ -15,7 +15,7 @@ class StrRef {
   bool operator==(const StrRef& rhs) const { return data == rhs.data; }
   bool operator!=(const StrRef& rhs) const { return data != rhs.data; }
   const char* get() const { return data; }
-  bool empty() const { return data == nullptr; }
+  bool is_null() const { return data == nullptr; }
   bool valid() const { return data != nullptr; }
   size_t length() const { return std::strlen(data); }
 

--- a/util/small_tag_map.h
+++ b/util/small_tag_map.h
@@ -142,7 +142,7 @@ class SmallTagMap : private detail::prime_number_hash_policy {
     const value_type* entries_;
     size_t num_buckets_;
 
-    bool is_empty(size_t idx) { return entries_[idx].first.empty(); }
+    bool is_empty(size_t idx) { return entries_[idx].first.is_null(); }
   };
 
   using const_iterator = templated_iterator<const value_type>;


### PR DESCRIPTION
The original thought behind the name was whether the reference is
pointing to something, similar to scala `Option[T]`, but it's not clear
whether the name refers to that or the length of the underlying string.

Rename it to be explicit about what it's actually checking.