### PR TITLE
Fix warnings and clean up the code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ npm-debug.log
 .newt.netflix_environment.sh
 cmake-build-*
 logs/
+.idea/

--- a/atlas_client.cc
+++ b/atlas_client.cc
@@ -5,13 +5,13 @@
 #include "util/logger.h"
 #include <iostream>
 
+using atlas::interpreter::ClientVocabulary;
+using atlas::interpreter::Interpreter;
 using atlas::meter::SubscriptionManager;
 using atlas::meter::SubscriptionRegistry;
 using atlas::meter::SystemClockWithOffset;
 using atlas::util::ConfigManager;
 using atlas::util::Logger;
-using atlas::interpreter::Interpreter;
-using atlas::interpreter::ClientVocabulary;
 
 static SystemClockWithOffset clockWithOffset;
 SubscriptionRegistry atlas_registry{
@@ -29,10 +29,10 @@ inline bool is_sane_environment() {
 
 class AtlasClient {
  public:
-  AtlasClient() noexcept : started{false} {
-    subscription_manager.reset(
-        new SubscriptionManager(config_manager, atlas_registry));
-  }
+  AtlasClient() noexcept
+      : started{false},
+        subscription_manager{
+            new SubscriptionManager(config_manager, atlas_registry)} {}
 
   void Start() {
     if (started) {
@@ -69,8 +69,8 @@ class AtlasClient {
   }
 
   void Push(const atlas::meter::Measurements& measurements) {
-    using atlas::interpreter::TagsValuePairs;
     using atlas::interpreter::TagsValuePair;
+    using atlas::interpreter::TagsValuePairs;
     using atlas::meter::Measurement;
 
     TagsValuePairs tagsValuePairs;
@@ -132,7 +132,7 @@ void SetNotifyAlertServer(bool notify) {
 
 void Init() {
   if (!atlas_client) {
-    atlas_client.reset(new AtlasClient());
+    atlas_client = std::make_unique<AtlasClient>();
   }
   atlas_client->Start();
 }

--- a/atlas_client.h
+++ b/atlas_client.h
@@ -12,7 +12,7 @@ void AddCommonTag(const char* key, const char* value);
 util::Config GetConfig();
 void PushMeasurements(const atlas::meter::Measurements& measurements);
 void SetLoggingDirs(const std::vector<std::string>& dirs);
-void SetLogSizes(size_t max_files, size_t max_size);
+void SetLogSizes(size_t max_size, size_t max_files);
 void UseConsoleLogger(int level);
 void SetNotifyAlertServer(bool notify);
 }  // namespace atlas

--- a/interpreter/context.h
+++ b/interpreter/context.h
@@ -2,7 +2,6 @@
 
 #include <memory>
 #include <stack>
-#include "../types.h"
 #include "expression.h"
 #include "query.h"
 
@@ -32,5 +31,5 @@ class Context {
 };
 
 std::ostream& operator<<(std::ostream& os, const Context& context);
-}  // interpreter
-}  // atlas
+}  // namespace interpreter
+}  // namespace atlas

--- a/interpreter/vocabulary.h
+++ b/interpreter/vocabulary.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../types.h"
 #include "context.h"
 #include "word.h"
 

--- a/meter/clock.h
+++ b/meter/clock.h
@@ -10,6 +10,8 @@ class Clock {
   virtual int64_t WallTime() const noexcept = 0;
 
   virtual int64_t MonotonicTime() const noexcept = 0;
+
+  virtual ~Clock() = default;
 };
 
 class SystemClock : public Clock {

--- a/meter/distribution_summary.h
+++ b/meter/distribution_summary.h
@@ -8,6 +8,7 @@ namespace meter {
 template <typename T>
 class DistributionSummaryNumber {
  public:
+  virtual ~DistributionSummaryNumber() = default;
   virtual void Record(T amount) noexcept = 0;
   virtual int64_t Count() const noexcept = 0;
   virtual T TotalAmount() const noexcept = 0;

--- a/meter/gauge.h
+++ b/meter/gauge.h
@@ -10,6 +10,7 @@ namespace meter {
 template <typename T>
 class Gauge {
  public:
+  virtual ~Gauge() = default;
   virtual double Value() const noexcept = 0;
   virtual void Update(T d) noexcept = 0;
 };

--- a/meter/id.h
+++ b/meter/id.h
@@ -3,8 +3,8 @@
 #include <map>
 #include <ostream>
 #include <unordered_map>
-#include "../types.h"
 #include "../util/intern.h"
+#include "../util/memory.h"
 #include "../util/small_tag_map.h"
 
 namespace atlas {

--- a/meter/long_task_timer.h
+++ b/meter/long_task_timer.h
@@ -16,6 +16,8 @@ namespace meter {
 ///
 class LongTaskTimer {
  public:
+  virtual ~LongTaskTimer() = default;
+
   /// Start keeping time for a task and return a task id that can be used to
   /// look up how long
   /// it has been running.

--- a/meter/measurement.h
+++ b/meter/measurement.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "id.h"
+#include <vector>
 
 namespace atlas {
 namespace meter {

--- a/meter/registry.h
+++ b/meter/registry.h
@@ -16,6 +16,8 @@ class Registry {
  public:
   using Meters = std::vector<std::shared_ptr<Meter>>;
 
+  virtual ~Registry() = default;
+
   virtual const Clock& clock() const noexcept = 0;
 
   virtual std::shared_ptr<Timer> timer(IdPtr id) noexcept = 0;

--- a/meter/subscription.h
+++ b/meter/subscription.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../types.h"
 #include "../interpreter/tags_value.h"
 #include <thread>
 

--- a/meter/timer.h
+++ b/meter/timer.h
@@ -6,6 +6,8 @@ namespace atlas {
 namespace meter {
 class Timer {
  public:
+  virtual ~Timer() = default;
+
   virtual void Record(std::chrono::nanoseconds nanos) = 0;
 
   virtual void Record(int64_t nanos) {

--- a/test/interpreter_test.cc
+++ b/test/interpreter_test.cc
@@ -1,15 +1,14 @@
 #include "../interpreter/interpreter.h"
 #include "../interpreter/all.h"
 #include "../util/logger.h"
-#include "../types.h"
 #include <gtest/gtest.h>
 
-using ::atlas::Strings;
-using atlas::util::intern_str;
 using atlas::util::Logger;
+using atlas::util::intern_str;
 
 using namespace atlas::interpreter;
 using namespace atlas::meter;
+using Strings = std::vector<std::string>;
 
 TEST(Interpreter, SplitEmpty) {
   Expressions result;
@@ -203,7 +202,9 @@ TEST(Interpreter, KeepTags) {
 }
 
 TEST(Interpreter, DropTags) {
-  auto context = exec("name,name1,:eq,k2,w1,:eq,:and,:count,(,k2,does.not.exist.tag,),:drop-tags");
+  auto context = exec(
+      "name,name1,:eq,k2,w1,:eq,:and,:count,(,k2,does.not.exist.tag,),:drop-"
+      "tags");
   ASSERT_EQ(1, context->StackSize());
 
   auto expr = context->PopExpression();

--- a/util/http.cc
+++ b/util/http.cc
@@ -1,5 +1,4 @@
 #include "http.h"
-#include "../types.h"
 #include "gzip.h"
 #include "json.h"
 #include "logger.h"

--- a/util/memory.h
+++ b/util/memory.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <memory>
+
+#if __cplusplus < 201402L
+namespace std {
+template <typename T, typename... Args>
+unique_ptr<T> make_unique(Args&&... args) {
+  return unique_ptr<T>(new T(forward<Args>(args)...));
+}
+}  // namespace std
+#endif

--- a/util/optional.h
+++ b/util/optional.h
@@ -2,12 +2,9 @@
 
 class OptionalString {
  public:
-  explicit OptionalString(const char* string) noexcept {
-    has_value = string != nullptr;
-    if (has_value) {
-      s = string;
-    }
-  }
+  explicit OptionalString(const char* string) noexcept
+      : has_value(string != nullptr), s(string != nullptr ? string : "") {}
+
   explicit OptionalString(const std::string& string)
       : has_value{true}, s{string} {}
 

--- a/util/small_tag_map.cc
+++ b/util/small_tag_map.cc
@@ -1,5 +1,6 @@
 #include "small_tag_map.h"
 #include "logger.h"
+#include <cassert>
 
 namespace atlas {
 namespace util {
@@ -26,9 +27,7 @@ void SmallTagMap::add(util::StrRef k_ref, util::StrRef v_ref) noexcept {
   if (ki.get() != nullptr) {
     entries_[i].second = v_ref;
   } else {
-    if (entries_[i].first.valid()) {
-      throw std::runtime_error("position has already been filled");
-    }
+    assert(entries_[i].first.is_null());
     entries_[i].first = k_ref;
     entries_[i].second = v_ref;
     ++actual_size_;
@@ -63,14 +62,18 @@ size_t SmallTagMap::hash() const noexcept {
 }
 
 bool SmallTagMap::operator==(const SmallTagMap& other) const noexcept {
-  if (other.size() != size()) return false;
+  if (other.size() != size()) {
+    return false;
+  }
 
   const auto N = num_buckets();
   for (auto i = 0u; i < N; ++i) {
     const auto& entry = entries_[i];
     if (entry.first.valid()) {
       bool eq = entry.second == other.at(entry.first);
-      if (!eq) return false;
+      if (!eq) {
+        return false;
+      }
     }
   }
   return true;

--- a/util/strings.h
+++ b/util/strings.h
@@ -15,7 +15,7 @@ inline std::string first_nonempty(
     std::initializer_list<std::string> list) noexcept {
   using namespace std;
   auto found = find_if(begin(list), end(list),
-                       [](const std::string& elt) { return !elt.empty(); });
+                       [](const string& elt) { return !elt.empty(); });
   return found != end(list) ? *found : "";
 }
 


### PR DESCRIPTION
* Add virtual destructors to interfaces
* Get rid of the `types.h` hack and make sure we only define
`std::make_unique` if not running under C++14 or newer.
* Do not throw from a `noexcept` function. (That would just call
`terminate()`) - switch to `assert`