### PR TITLE
HTTP clean up

### DIFF
--- a/atlas_client.cc
+++ b/atlas_client.cc
@@ -2,6 +2,7 @@
 #include "interpreter/interpreter.h"
 #include "meter/subscription_manager.h"
 #include "util/config_manager.h"
+#include "util/http.h"
 #include "util/logger.h"
 #include <iostream>
 
@@ -12,6 +13,7 @@ using atlas::meter::SubscriptionRegistry;
 using atlas::meter::SystemClockWithOffset;
 using atlas::util::ConfigManager;
 using atlas::util::Logger;
+using atlas::util::http;
 
 static SystemClockWithOffset clockWithOffset;
 SubscriptionRegistry atlas_registry{
@@ -38,6 +40,7 @@ class AtlasClient {
     if (started) {
       return;
     }
+    http::global_init();
     auto logger = Logger();
     auto cfg = GetConfig();
     if (cfg->ShouldForceStart() || is_sane_environment()) {
@@ -61,6 +64,7 @@ class AtlasClient {
       subscription_manager->Stop(&clockWithOffset);
       config_manager.Stop();
       started = false;
+      http::global_shutdown();
     }
   }
 

--- a/util/http.cc
+++ b/util/http.cc
@@ -2,6 +2,7 @@
 #include "gzip.h"
 #include "json.h"
 #include "logger.h"
+#include "memory.h"
 #include "strings.h"
 
 #include <curl/curl.h>
@@ -13,38 +14,131 @@ namespace util {
 
 namespace {
 
-struct MemStruct {
-  void* memory;
-  size_t size;
+class CurlHeaders {
+ public:
+  CurlHeaders() = default;
+  ~CurlHeaders() {
+    curl_slist_free_all(list_);
+  }
+  CurlHeaders(const CurlHeaders&) = delete;
+  CurlHeaders(CurlHeaders&&) = delete;
+  CurlHeaders& operator=(const CurlHeaders&) = delete;
+  CurlHeaders& operator=(CurlHeaders&&) = delete;
+  void append(const std::string& string) {
+    list_ = curl_slist_append(list_, string.c_str());
+  }
+  curl_slist* headers() {
+    return list_;
+  }
+ private:
+  curl_slist* list_{nullptr};
+};
+
+constexpr const char* const kUserAgent = "atlas-native/1.0";
+
+class CurlHandle {
+ public:
+  CurlHandle() noexcept : handle_{curl_easy_init()} {
+    curl_easy_setopt(handle_, CURLOPT_ACCEPT_ENCODING, "gzip");
+    curl_easy_setopt(handle_, CURLOPT_USERAGENT, kUserAgent);
+  }
+
+  CurlHandle(const CurlHandle&) = delete;
+
+  CurlHandle& operator=(const CurlHandle&) = delete;
+
+  CurlHandle(CurlHandle&& other) = delete;
+
+  CurlHandle& operator=(CurlHandle&& other) = delete;
+
+  ~CurlHandle() {
+    // nullptr is handled by curl
+    curl_easy_cleanup(handle_);
+  }
+
+  CURL* handle() const noexcept {
+    return handle_;
+  }
+
+  CURLcode perform() {
+    return curl_easy_perform(handle());
+  }
+
+  CURLcode set_opt(CURLoption option, const void* param) {
+    return curl_easy_setopt(handle(), option, param);
+  }
+
+  int status_code() {
+    // curl requires this to be a long
+    long http_code = 400;
+    curl_easy_getinfo(handle(), CURLINFO_RESPONSE_CODE, &http_code);
+    return static_cast<int>(http_code);
+  }
+
+  void set_url(const std::string& url) {
+    set_opt(CURLOPT_URL, url.c_str());
+  }
+
+  void set_headers(std::unique_ptr<CurlHeaders> headers) {
+    headers_ = std::move(headers);
+    set_opt(CURLOPT_HTTPHEADER, headers_->headers());
+  }
+
+  void set_connect_timeout(int connect_timeout_seconds) {
+     curl_easy_setopt(handle_, CURLOPT_CONNECTTIMEOUT, (long)connect_timeout_seconds);
+  }
+
+  void set_read_timeout(int read_timeout_seconds) {
+    curl_easy_setopt(handle_, CURLOPT_TIMEOUT, (long)read_timeout_seconds);
+  }
+
+  void post_payload(const Bytef* payload, size_t size) {
+    curl_easy_setopt(handle_, CURLOPT_POST, 1L);
+    curl_easy_setopt(handle_, CURLOPT_POSTFIELDS, payload);
+    curl_easy_setopt(handle_, CURLOPT_POSTFIELDSIZE, size);
+  }
+ private:
+  CURL* handle_;
+  std::unique_ptr<CurlHeaders> headers_;
+};
+
+class Buffer {
+ public:
+  Buffer(): memory(static_cast<char*>(malloc(1))) {}
+  ~Buffer() {
+    free(memory);
+  }
+  Buffer(const Buffer&) = delete;
+  Buffer& operator=(const Buffer&) = delete;
+  Buffer& operator=(Buffer&&) = delete;
+  Buffer(Buffer&&) = delete;
+  void append(void* data, size_t data_size) {
+    memory = static_cast<char*>(realloc(memory, size + data_size + 1));
+    if (memory == nullptr) {
+      throw std::bad_alloc();
+    }
+
+    memcpy(memory + size, data, data_size);
+    size += data_size;
+    memory[size] = 0;
+  }
+  void assign(std::string* s) {
+    s->assign(memory, size);
+  }
+ private:
+  char* memory;
+  size_t size = 0;
 };
 
 size_t write_memory_callback(void* contents, size_t size, size_t nmemb,
                              void* userp) {
   auto real_size = size * nmemb;
-  auto mem = static_cast<MemStruct*>(userp);
-  mem->memory = realloc(mem->memory, mem->size + real_size + 1);
-  if (mem->memory == nullptr) {
-    throw std::bad_alloc();
-  }
-
-  auto memory = static_cast<char*>(mem->memory);
-  memcpy(memory + mem->size, contents, real_size);
-  mem->size += real_size;
-  memory[mem->size] = 0;
+  auto buffer = static_cast<Buffer*>(userp);
+  buffer->append(contents, real_size);
   return real_size;
 }
-}  // namespace
 
-constexpr const char* const kUserAgent = "atlas-native/1.0";
-
-static void SetOptions(void* curl, int connect_timeout, int read_timeout) {
-  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, (long)connect_timeout);
-  curl_easy_setopt(curl, CURLOPT_TIMEOUT, (long)read_timeout);
-  curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
-  curl_easy_setopt(curl, CURLOPT_USERAGENT, kUserAgent);
-}
-
-static size_t header_callback(char* buffer, size_t size, size_t n_items,
+size_t header_callback(char* buffer, size_t size, size_t n_items,
                               void* userdata) {
   std::string header{buffer, size * n_items};
   if (util::IStartsWith(header, "Etag: ")) {
@@ -57,81 +151,80 @@ static size_t header_callback(char* buffer, size_t size, size_t n_items,
   return size * n_items;
 }
 
+}  // namespace
+
 int http::conditional_get(const std::string& url, std::string& etag,
                           int connect_timeout, int read_timeout,
                           std::string& res) const {
   auto logger = Logger();
   logger->debug("Conditionally getting url: {} etag: {}", url, etag);
-  auto curl = curl_easy_init();
+  CurlHandle curl;
   // url to get
-  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+  curl.set_url(url);
   // send all data to this function
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_memory_callback);
+  curl.set_opt(CURLOPT_WRITEFUNCTION, reinterpret_cast<const void*>(write_memory_callback));
   if (!etag.empty()) {
     std::string ifNone = std::string("If-None-Match: ") + etag;
-    auto headers = curl_slist_append(nullptr, ifNone.c_str());
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    auto headers = std::make_unique<CurlHeaders>();
+    headers->append(ifNone);
+    curl.set_headers(std::move(headers));
   }
 
-  MemStruct chunk{malloc(1), 0};  // we'll realloc as needed
-  SetOptions(curl, connect_timeout, read_timeout);
+  Buffer buffer;
+  curl.set_connect_timeout(connect_timeout);
+  curl.set_read_timeout(read_timeout);
   // pass chunk to the callback function
-  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &chunk);
-  curl_easy_setopt(curl, CURLOPT_HEADERDATA, &etag);
-  curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
-  auto curl_res = curl_easy_perform(curl);
-  // due to curl_easy_getinfo taking a long*
-  long http_code = 400;
+  curl.set_opt(CURLOPT_WRITEDATA, &buffer);
+  curl.set_opt(CURLOPT_HEADERDATA, &etag);
+  curl.set_opt(CURLOPT_HEADERFUNCTION, reinterpret_cast<void*>(header_callback));
+  auto curl_res = curl.perform();
+  int http_code = 400;
   bool error = false;
 
   if (curl_res != CURLE_OK) {
     logger->error("Failed to get {} {}", url, curl_easy_strerror(curl_res));
     error = true;
   } else {
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    http_code = curl.status_code();
     if (http_code != 304) {  // if we got something back
-      res.assign(static_cast<char*>(chunk.memory), chunk.size);
+      buffer.assign(&res);
     }
   }
-  free(chunk.memory);
-  curl_easy_cleanup(curl);
   if (!error) {
     logger->debug("Was able to fetch {} - status code: ", url, http_code);
     if (http_code == 0) {
       http_code = 200;
     }  // for file:///
   }
-  return static_cast<int>(http_code);
+  return http_code;
 }
 
 int http::get(const std::string& url, int connect_timeout, int read_timeout,
               std::string& res) const {
   auto logger = Logger();
   logger->debug("Getting url: {}", url);
-  auto curl = curl_easy_init();
+  CurlHandle curl;
   // url to get
-  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+  curl.set_url(url);
   // send all data to this function
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_memory_callback);
+  curl.set_opt(CURLOPT_WRITEFUNCTION, reinterpret_cast<const void*>(write_memory_callback));
 
-  MemStruct chunk{malloc(1),  // we'll realloc as needed
-                  0};
+  Buffer buffer;
   // pass chunk to the callback function
-  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &chunk);
-  SetOptions(curl, connect_timeout, read_timeout);
-  auto curl_res = curl_easy_perform(curl);
-  long http_code = 400;
-  bool error = false;
+  curl.set_opt(CURLOPT_WRITEDATA, &buffer);
+  curl.set_connect_timeout(connect_timeout);
+  curl.set_read_timeout(read_timeout);
+  auto curl_res = curl.perform();
+  auto http_code = 400;
+  auto error = false;
 
   if (curl_res != CURLE_OK) {
     logger->error("Failed to get {} {}", url, curl_easy_strerror(curl_res));
     error = true;
   } else {
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-    res.assign(static_cast<char*>(chunk.memory), chunk.size);
+    http_code = curl.status_code();
+    buffer.assign(&res);
   }
-  free(chunk.memory);
-  curl_easy_cleanup(curl);
   if (!error) {
     logger->debug("Was able to fetch {} - status code: {}", url, http_code);
     // for file:///
@@ -139,52 +232,51 @@ int http::get(const std::string& url, int connect_timeout, int read_timeout,
       http_code = 200;
     }
   }
-  return static_cast<int>(http_code);
+  return http_code;
 }
 
-static int do_post(const char* url, int connect_timeout, int read_timeout,
-                   curl_slist* headers, const Bytef* payload, size_t size) {
-  auto curl = curl_easy_init();
+static int do_post(const std::string& url, int connect_timeout, int read_timeout,
+                   std::unique_ptr<CurlHeaders> headers,
+                   const Bytef* payload, size_t size) {
+  CurlHandle curl;
+  curl.set_connect_timeout(connect_timeout);
+  curl.set_read_timeout(read_timeout);
 
   auto logger = Logger();
   logger->info("POSTing to url: {}", url);
-  SetOptions(curl, connect_timeout, read_timeout);
-  curl_easy_setopt(curl, CURLOPT_URL, url);
-  curl_easy_setopt(curl, CURLOPT_POST, 1L);
-  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-  curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload);
-  curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, size);
+  curl.set_url(url);
+  curl.set_headers(std::move(headers));
+  curl.post_payload(payload, size);
 
-  auto curl_res = curl_easy_perform(curl);
-  bool error = false;
-  long http_code = 400;
+  auto curl_res = curl.perform();
+  auto error = false;
+  auto http_code = 400;
 
   if (curl_res != CURLE_OK) {
     logger->error("Failed to POST {}: {}", url, curl_easy_strerror(curl_res));
     error = true;
   } else {
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    http_code = curl.status_code();
   }
 
-  curl_easy_cleanup(curl);
   if (!error) {
     logger->info("Was able to POST to {} - status code: {}", url, http_code);
   }
-  curl_slist_free_all(headers);
-  return static_cast<int>(http_code);
+  return http_code;
 }
 
 int http::post(const std::string& url, int connect_timeout, int read_timeout,
                const char* content_type, const char* payload,
                size_t size) const {
-  auto headers = curl_slist_append(nullptr, content_type);
+  auto headers = std::make_unique<CurlHeaders>();
+  headers->append(content_type);
 
   if (size <= 16) {
-    return do_post(url.c_str(), connect_timeout, read_timeout, headers,
+    return do_post(url, connect_timeout, read_timeout, std::move(headers),
                    reinterpret_cast<const Bytef*>(payload), size);
   }
 
-  headers = curl_slist_append(headers, "Content-Encoding: gzip");
+  headers->append("Content-Encoding: gzip");
   auto compressed_size = compressBound(size) + 16;
   auto compressed_payload =
       std::unique_ptr<Bytef[]>(new Bytef[compressed_size]);
@@ -196,11 +288,10 @@ int http::post(const std::string& url, int connect_timeout, int read_timeout,
         "Failed to compress payload: {}, while posting to {} - uncompressed "
         "size: {}",
         compress_res, url, size);
-    curl_slist_free_all(headers);
     return 400;
   }
 
-  return do_post(url.c_str(), connect_timeout, read_timeout, headers,
+  return do_post(url, connect_timeout, read_timeout, std::move(headers),
                  compressed_payload.get(), compressed_size);
 }
 
@@ -211,6 +302,14 @@ int http::post(const std::string& url, int connect_timeout, int read_timeout,
   auto c_str = JsonGetString(buffer, payload);
   return post(url, connect_timeout, read_timeout, json_type, c_str,
               strlen(c_str));
+}
+
+void http::global_init() noexcept {
+  curl_global_init(CURL_GLOBAL_ALL);
+}
+
+void http::global_shutdown() noexcept {
+  curl_global_cleanup();
 }
 
 }  // namespace util

--- a/util/http.h
+++ b/util/http.h
@@ -23,6 +23,9 @@ class http {
 
   int post(const std::string& url, int connect_timeout, int read_timeout,
            const rapidjson::Document& payload) const;
+
+  static void global_init() noexcept;
+  static void global_shutdown() noexcept;
 };
 }
 }


### PR DESCRIPTION
* Use RAII for dealing with the easy handles, lists, and buffers.

* Add global init and shutdown methods, which are needed by curl

This fixes a memory leak in the conditional get implementation (not
freeing the headers).