### PR TITLE
Http client takes options in the constructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 add_library(atlasclient SHARED ${LIB_SOURCE_FILES})
 set_target_properties(atlasclient PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wno-missing-braces")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCURL_STATICLIB -pedantic -Werror -fno-rtti -Wall -Wno-missing-braces -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCURL_STATICLIB -Werror -fno-rtti -Wall -Wno-missing-braces -std=c++11")
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   configure_file(${CMAKE_SOURCE_DIR}/bundle/libcurl-linux.a libcurl.a COPYONLY)

--- a/test/http_test.cc
+++ b/test/http_test.cc
@@ -234,12 +234,12 @@ TEST(HttpTest, Post) {
   auto logger = Logger();
   logger->info("Server started on port {}", port);
 
-  http client;
+  http client{1, 1};
   std::ostringstream os;
   os << "http://localhost:" << port << "/foo";
   auto url = os.str();
   const std::string post_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-  client.post(url, 1, 1, "Content-type: application/json", post_data.c_str(),
+  client.post(url, "Content-type: application/json", post_data.c_str(),
               post_data.length());
 
   server.stop();
@@ -277,12 +277,12 @@ TEST(HttpTest, Timeout) {
   auto logger = Logger();
   logger->info("Server started on port {}", port);
 
-  http client;
+  http client{1, 1};
   std::ostringstream os;
   os << "http://localhost:" << port << "/foo";
   auto url = os.str();
   const std::string post_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-  client.post(url, 1, 1, "Content-type: application/json", post_data.c_str(),
+  client.post(url, "Content-type: application/json", post_data.c_str(),
               post_data.length());
 
   server.stop();

--- a/test/http_test.cc
+++ b/test/http_test.cc
@@ -6,6 +6,7 @@
 #include <sys/types.h>
 #include <zlib.h>
 
+#include "../util/config_manager.h"
 #include "../util/gzip.h"
 #include "../util/http.h"
 #include "../util/logger.h"
@@ -234,7 +235,8 @@ TEST(HttpTest, Post) {
   auto logger = Logger();
   logger->info("Server started on port {}", port);
 
-  http client{1, 1};
+  auto cfg = atlas::util::DefaultConfig();
+  http client{*cfg};
   std::ostringstream os;
   os << "http://localhost:" << port << "/foo";
   auto url = os.str();
@@ -277,7 +279,8 @@ TEST(HttpTest, Timeout) {
   auto logger = Logger();
   logger->info("Server started on port {}", port);
 
-  http client{1, 1};
+  auto cfg = atlas::util::DefaultConfig();
+  http client{*cfg};
   std::ostringstream os;
   os << "http://localhost:" << port << "/foo";
   auto url = os.str();

--- a/util/http.h
+++ b/util/http.h
@@ -6,26 +6,31 @@
 #include <string>
 
 namespace atlas {
-
 namespace util {
 
 class http {
  public:
+  http(int connect_timeout_seconds, int read_timeout_seconds)
+      : connect_timeout_(connect_timeout_seconds),
+        read_timeout_(read_timeout_seconds) {}
+
   int conditional_get(const std::string& url, std::string& etag,
-                      int connect_timeout, int read_timeout,
-                      std::string& res) const;
+                      std::string* res) const;
 
-  int get(const std::string& url, int connect_timeout, int read_timeout,
-          std::string& res) const;
+  int get(const std::string& url, std::string* res) const;
 
-  int post(const std::string& url, int connect_timeout, int read_timeout,
-           const char* content_type, const char* payload, size_t size) const;
+  int post(const std::string& url, const char* content_type,
+           const char* payload, size_t size) const;
 
-  int post(const std::string& url, int connect_timeout, int read_timeout,
-           const rapidjson::Document& payload) const;
+  int post(const std::string& url, const rapidjson::Document& payload) const;
 
   static void global_init() noexcept;
   static void global_shutdown() noexcept;
+
+ private:
+  int connect_timeout_;
+  int read_timeout_;
 };
-}
-}
+
+}  // namespace util
+}  // namespace atlas

--- a/util/http.h
+++ b/util/http.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "config.h"
 #include <rapidjson/document.h>
 #include <spdlog/spdlog.h>
 #include <memory>
@@ -10,9 +11,9 @@ namespace util {
 
 class http {
  public:
-  http(int connect_timeout_seconds, int read_timeout_seconds)
-      : connect_timeout_(connect_timeout_seconds),
-        read_timeout_(read_timeout_seconds) {}
+  explicit http(const Config& config)
+      : connect_timeout_(config.ConnectTimeout()),
+        read_timeout_(config.ReadTimeout()) {}
 
   int conditional_get(const std::string& url, std::string& etag,
                       std::string* res) const;


### PR DESCRIPTION
Instead of passing common options, like timeouts, to each of the calls
make the client takes the options in the constructor. This should allow
us to extend the options at a later time (when adding retries)