### PR TITLE
Do not notify alert server about on-instance alerts

### DIFF
--- a/resources/atlas-config-reference.json
+++ b/resources/atlas-config-reference.json
@@ -6,7 +6,6 @@
   "subscriptionsUrl": "http://atlas-lwcapi-iep.$EC2_REGION.iep$NETFLIX_ENVIRONMENT.netflix.net/lwc/api/v1/$NETFLIX_AUTO_SCALE_GROUP",
   "publishUrl": "http://atlas-pub-$EC2_OWNER_ID.$EC2_REGION.$NETFLIX_ACCOUNT.netflix.net/api/v1/publish-fast",
   "checkClusterUrl": "http://atlas-alert-api-$EC2_OWNER_ID.$EC2_REGION.$NETFLIX_ENVIRONMENT.netflix.net/alertchecker/checkCluster/$NETFLIX_CLUSTER",
-  "notifyAlertServer": true,
   "publishConfig": [
     ":true,:all"
   ],

--- a/util/config.cc
+++ b/util/config.cc
@@ -13,7 +13,7 @@ Config::Config(const std::string& disabled_file,
                const std::string& subscriptions_endpoint,
                const std::string& publish_endpoint, bool validate_metrics,
                const std::string& check_cluster_endpoint,
-               bool notifyAlertServer, std::vector<std::string> publish_config,
+               std::vector<std::string> publish_config,
                int64_t subscription_refresh, int connect_timeout,
                int read_timeout, int batch_size, bool force_start,
                bool enable_main, bool enable_subscriptions, bool dump_metrics,
@@ -25,7 +25,6 @@ Config::Config(const std::string& disabled_file,
       publish_endpoint_(ExpandEnvVars(publish_endpoint)),
       validate_metrics_(validate_metrics),
       check_cluster_endpoint_(ExpandEnvVars(check_cluster_endpoint)),
-      notify_alert_server_(notifyAlertServer),
       publish_config_(std::move(publish_config)),
       subscription_refresh_(subscription_refresh),
       connect_timeout_(connect_timeout),
@@ -58,16 +57,14 @@ bool Config::AreSubsEnabled() const noexcept {
 std::string ConfigToString(const Config& config) noexcept {
   std::ostringstream os;
   os << std::boolalpha;
-  os << "Config{eval_endpoint=" << config.EvalEndpoint() << '\n'
-     << ", subs_endpoint=" << config.SubsEndpoint() << '\n'
-     << ", subs_refresh=" << config.SubRefreshMillis() << "ms"
-     << ", publish=" << config.PublishEndpoint() << '\n'
-     << ", notifyAlertServer=" << config.ShouldNotifyAlertServer() << '\n'
-     << ", validateMetrics=" << config.ShouldValidateMetrics() << '\n'
+  os << "Config{eval_endpoint=" << config.EvalEndpoint()
+     << ", subs_endpoint=" << config.SubsEndpoint()
+     << ", subs_refresh=" << config.SubRefreshMillis()
+     << ", publish=" << config.PublishEndpoint()
+     << ", validateMetrics=" << config.ShouldValidateMetrics()
      << ", forceStart=" << config.ShouldForceStart()
-     << ", mainEnabled=" << config.IsMainEnabled() << '\n'
-     << ", subsEnabled=" << config.AreSubsEnabled() << '\n'
-     << ", publish_cfg=";
+     << ", mainEnabled=" << config.IsMainEnabled()
+     << ", subsEnabled=" << config.AreSubsEnabled() << ", publish_cfg=";
   const auto& pub_cfg = config.PublishConfig();
   dump_vector(os, pub_cfg);
   os << ", dump_metrics=" << config.ShouldDumpMetrics()

--- a/util/config.h
+++ b/util/config.h
@@ -18,7 +18,7 @@ class Config {
   Config(const std::string& disabled_file, const std::string& evaluate_endpoint,
          const std::string& subscriptions_endpoint,
          const std::string& publish_endpoint, bool validate_metrics,
-         const std::string& check_cluster_endpoint, bool notifyAlertServer,
+         const std::string& check_cluster_endpoint,
          std::vector<std::string> publish_config, int64_t subscription_refresh,
          int connect_timeout, int read_timeout, int batch_size,
          bool force_start, bool enable_main, bool enable_subscriptions,
@@ -38,7 +38,6 @@ class Config {
   std::string LoggingDirectory() const noexcept;
   bool ShouldValidateMetrics() const noexcept { return validate_metrics_; }
   bool ShouldForceStart() const noexcept { return force_start_; }
-  bool ShouldNotifyAlertServer() const noexcept { return notify_alert_server_; }
   bool IsMainEnabled() const noexcept;
   bool AreSubsEnabled() const noexcept;
   bool ShouldDumpMetrics() const noexcept { return dump_metrics_; }
@@ -72,7 +71,6 @@ class Config {
   std::string publish_endpoint_;
   bool validate_metrics_;
   std::string check_cluster_endpoint_;
-  bool notify_alert_server_;
   std::vector<std::string> publish_config_;
   int64_t subscription_refresh_;
   int connect_timeout_;

--- a/util/config_manager.h
+++ b/util/config_manager.h
@@ -11,7 +11,7 @@
 namespace atlas {
 namespace util {
 
-std::unique_ptr<Config> DefaultConfig(bool notify = true) noexcept;
+std::unique_ptr<Config> DefaultConfig() noexcept;
 
 class ConfigManager {
  public:
@@ -25,18 +25,19 @@ class ConfigManager {
 
   void AddCommonTag(const char* key, const char* value) noexcept;
 
-  void SetNotifyAlertServer(bool notify) noexcept;
+  // deprecated - alert server uses the streaming path to check on-instance
+  // alerts so this is no longer needed
+  void SetNotifyAlertServer(bool /*unused*/) noexcept;
 
  private:
   mutable std::mutex config_mutex;
   std::shared_ptr<Config> current_config_;
   std::atomic<bool> should_run_{false};
   meter::Tags extra_tags_;
-  bool default_notify_ = true;
 
   void refresher() noexcept;
   void refresh_configs() noexcept;
   std::unique_ptr<Config> get_current_config() noexcept;
 };
-}
-}
+}  // namespace util
+}  // namespace atlas


### PR DESCRIPTION
Remove the hack that was in place to notify alert server about our lack
of on-instance alert support. The alert server now checks on-instance
alerts using the streaming path.