### PR TITLE
Send batches in parallel (optionally)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ CMakeFiles/
 CTestTestfile.cmake
 Makefile
 cmake_install.cmake
-build/
+build
+build-*
 node_modules/
 npm-debug.log
 .newt.netflix_environment.sh

--- a/resources/atlas-config-reference.json
+++ b/resources/atlas-config-reference.json
@@ -18,5 +18,6 @@
   "subscriptionsRefreshMillis": 10000,
   "connectTimeout": 6,
   "readTimeout": 20,
+  "sendInParallel": false,
   "batchSize": 10000
 }

--- a/util/config.cc
+++ b/util/config.cc
@@ -17,8 +17,9 @@ Config::Config(const std::string& disabled_file,
                int64_t subscription_refresh, int connect_timeout,
                int read_timeout, int batch_size, bool force_start,
                bool enable_main, bool enable_subscriptions, bool dump_metrics,
-               bool dump_subscriptions, int log_verbosity, size_t log_max_size,
-               size_t log_max_files, meter::Tags common_tags) noexcept
+               bool dump_subscriptions, int log_verbosity,
+               bool send_in_parallel, size_t log_max_size, size_t log_max_files,
+               meter::Tags common_tags) noexcept
     : disabled_file_watcher_(disabled_file),
       evaluate_endpoint_(ExpandEnvVars(evaluate_endpoint)),
       subscriptions_endpoint_(ExpandEnvVars(subscriptions_endpoint)),
@@ -37,6 +38,7 @@ Config::Config(const std::string& disabled_file,
       dump_metrics_(dump_metrics),
       dump_subscriptions_(dump_subscriptions),
       log_verbosity_(log_verbosity),
+      send_in_parallel_(send_in_parallel),
       log_max_size_(log_max_size),
       log_max_files_(log_max_files),
       common_tags_(std::move(common_tags)) {}
@@ -73,6 +75,7 @@ std::string ConfigToString(const Config& config) noexcept {
   os << ", dump_metrics=" << config.ShouldDumpMetrics()
      << ", dump_subs=" << config.ShouldDumpSubs()
      << ", batch=" << config.BatchSize()
+     << ", send_in_parallel=" << config.SendInParallel()
      << ", Timeouts(C=" << config.ConnectTimeout()
      << ",R=" << config.ReadTimeout()
      << "), logVerbosity=" << config.LogVerbosity() << ")\n"

--- a/util/config.h
+++ b/util/config.h
@@ -23,7 +23,7 @@ class Config {
          int connect_timeout, int read_timeout, int batch_size,
          bool force_start, bool enable_main, bool enable_subscriptions,
          bool dump_metrics, bool dump_subscriptions, int log_verbosity,
-         size_t log_max_size, size_t log_max_files,
+         bool send_in_parallel, size_t log_max_size, size_t log_max_files,
          meter::Tags common_tags) noexcept;
 
   std::string EvalEndpoint() const noexcept { return evaluate_endpoint_; }
@@ -57,6 +57,7 @@ class Config {
   std::string DisabledFile() const noexcept {
     return disabled_file_watcher_.file_name();
   }
+  bool SendInParallel() const noexcept { return send_in_parallel_; }
 
   // for testing
   Config WithPublishConfig(std::vector<std::string> publish_config) {
@@ -84,6 +85,7 @@ class Config {
   bool dump_metrics_;
   bool dump_subscriptions_;
   int log_verbosity_;
+  bool send_in_parallel_;
   size_t log_max_size_;
   size_t log_max_files_;
   meter::Tags common_tags_;

--- a/util/config_manager.cc
+++ b/util/config_manager.cc
@@ -141,6 +141,10 @@ static std::unique_ptr<Config> DocToConfig(
                         ? document["batchSize"].GetInt()
                         : defaults->BatchSize();
 
+  auto send_in_parallel = document.HasMember("sendInParallel")
+                              ? document["sendInParallel"].GetBool()
+                              : defaults->SendInParallel();
+
   auto log_verbosity = document.HasMember("logVerbosity")
                            ? document["logVerbosity"].GetInt()
                            : defaults->LogVerbosity();
@@ -158,7 +162,8 @@ static std::unique_ptr<Config> DocToConfig(
       validate_metrics, check_cluster_endpoint, notify_alert_server,
       publish_config, sub_refresh, connect_timeout, read_timeout, batch_size,
       force_start, main_enabled, subs_enabled, dump_metrics, dump_subscriptions,
-      log_verbosity, log_max_size, log_max_files, get_default_common_tags());
+      log_verbosity, send_in_parallel, log_max_size, log_max_files,
+      get_default_common_tags());
 }
 
 static std::unique_ptr<Config> ParseConfigFile(
@@ -202,8 +207,10 @@ std::unique_ptr<Config> DefaultConfig(bool notify) noexcept {
       // enable main but not subscriptions yet (need clusters in main account)
       true, false,
       // do not dump main or subs
-      false, false, kDefaultVerbosity, log_num_size.max_size,
-      log_num_size.max_files, get_default_common_tags());
+      false, false, kDefaultVerbosity,
+      // do not send metrics in parallel to reduce memory footprint used
+      false, log_num_size.max_size, log_num_size.max_files,
+      get_default_common_tags());
 }
 
 static constexpr const char* const kGlobalFile =

--- a/util/gzip.cc
+++ b/util/gzip.cc
@@ -7,6 +7,10 @@
 namespace atlas {
 namespace util {
 
+static constexpr int kWindowBits =
+    15 + kGzipHeaderSize;            // 32k window (max size)
+static constexpr int kMemLevel = 9;  // max memory for optimal speed
+
 int gzip_compress(Bytef* dest, uLongf* destLen, const Bytef* source,
                   uLong sourceLen) {
   // no initialization due to gcc 4.8 bug
@@ -20,8 +24,8 @@ int gzip_compress(Bytef* dest, uLongf* destLen, const Bytef* source,
   stream.zfree = static_cast<free_func>(nullptr);
   stream.opaque = static_cast<voidpf>(nullptr);
 
-  auto err = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 9,
-                          Z_DEFAULT_STRATEGY);
+  auto err = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED,
+                          kWindowBits, kMemLevel, Z_DEFAULT_STRATEGY);
   if (err != Z_OK) {
     return err;
   }
@@ -47,7 +51,7 @@ int gzip_uncompress(Bytef* dest, uLongf* destLen, const Bytef* source,
   stream.zalloc = static_cast<alloc_func>(nullptr);
   stream.zfree = static_cast<free_func>(nullptr);
 
-  auto err = inflateInit2(&stream, 31);
+  auto err = inflateInit2(&stream, kWindowBits);
   if (err != Z_OK) {
     return err;
   }

--- a/util/gzip.h
+++ b/util/gzip.h
@@ -5,9 +5,11 @@
 namespace atlas {
 namespace util {
 
+static constexpr int kGzipHeaderSize = 16;  // size of the gzip header
+
 int gzip_compress(Bytef* dest, uLongf* destLen, const Bytef* source,
                   uLong sourceLen);
 int gzip_uncompress(Bytef* dest, uLongf* destLen, const Bytef* source,
                     uLong sourceLen);
-}
-}
+}  // namespace util
+}  // namespace atlas

--- a/util/http.cc
+++ b/util/http.cc
@@ -5,9 +5,12 @@
 #include "memory.h"
 #include "strings.h"
 
+#include <algorithm>
 #include <curl/curl.h>
+#include <curl/multi.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
+#include <sstream>
 
 namespace atlas {
 namespace util {
@@ -256,6 +259,9 @@ static int do_post(const std::string& url, int connect_timeout,
   return http_code;
 }
 
+static constexpr const char* const kJsonType = "Content-Type: application/json";
+static constexpr const char* const kGzipEncoding = "Content-Encoding: gzip";
+
 int http::post(const std::string& url, const char* content_type,
                const char* payload, size_t size) const {
   auto headers = std::make_unique<CurlHeaders>();
@@ -266,7 +272,7 @@ int http::post(const std::string& url, const char* content_type,
                    reinterpret_cast<const Bytef*>(payload), size);
   }
 
-  headers->append("Content-Encoding: gzip");
+  headers->append(kGzipEncoding);
   auto compressed_size = compressBound(size) + 16;
   auto compressed_payload =
       std::unique_ptr<Bytef[]>(new Bytef[compressed_size]);
@@ -285,12 +291,131 @@ int http::post(const std::string& url, const char* content_type,
                  compressed_payload.get(), compressed_size);
 }
 
-static constexpr const char* const json_type = "Content-Type: application/json";
 int http::post(const std::string& url,
                const rapidjson::Document& payload) const {
   rapidjson::StringBuffer buffer;
   auto c_str = JsonGetString(buffer, payload);
-  return post(url, json_type, c_str, strlen(c_str));
+  return post(url, kJsonType, c_str, std::strlen(c_str));
+}
+
+class CurlMultiHandle {
+ public:
+  CurlMultiHandle() : multi_handle_(curl_multi_init()) {}
+  CurlMultiHandle(const CurlMultiHandle&) = delete;
+  CurlMultiHandle(CurlMultiHandle&&) = delete;
+  CurlMultiHandle& operator=(const CurlMultiHandle&) = delete;
+  CurlMultiHandle& operator=(CurlMultiHandle&&) = delete;
+  ~CurlMultiHandle() { curl_multi_cleanup(multi_handle_); }
+
+  std::vector<int> perform_all(
+      const std::vector<std::unique_ptr<CurlHandle>>& easy_handles) {
+    for (const auto& h : easy_handles) {
+      curl_multi_add_handle(multi_handle_, h->handle());
+    }
+
+    auto still_running = 0;
+    auto repeats = 0;
+    do {
+      auto mc = curl_multi_perform(multi_handle_, &still_running);
+      auto numfds = 0;
+      if (mc == CURLM_OK) {
+        // wait for activity, timeout, or "nothing"
+        mc = curl_multi_wait(multi_handle_, nullptr, 0, 1000, &numfds);
+      }
+      if (mc != CURLM_OK) {
+        Logger()->warn("curl_multi failed: {}", curl_multi_strerror(mc));
+        break;
+      }
+
+      // 'numfds' being zero means either a timeout or no file descriptors to
+      // wait for. Try timeout on first occurrence, then assume no file
+      // descriptors and no file descriptors to wait for means wait for 100
+      // milliseconds.
+      if (numfds == 0) {
+        repeats++;  // count number of repeated zero numfds
+        if (repeats > 1) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+      } else {
+        repeats = 0;
+      }
+    } while (still_running > 0);
+
+    CURLMsg* msg; /* for picking up messages with the transfer status */
+    int msgs_left;
+    std::vector<int> res(easy_handles.size());
+    std::fill(res.begin(), res.end(), 400);
+    while ((msg = curl_multi_info_read(multi_handle_, &msgs_left)) != nullptr) {
+      if (msg->msg == CURLMSG_DONE) {
+        // Find out which handle this message is about
+        for (auto i = 0u; i < easy_handles.size(); i++) {
+          auto easy_handle = easy_handles[i]->handle();
+          bool found = (msg->easy_handle == easy_handle);
+          if (found) {
+            auto easy_code = msg->data.result;
+            if (easy_code == CURLE_OK) {
+              res.at(i) = easy_handles[i]->status_code();
+            } else {
+              Logger()->warn("Failed batch: {}", curl_easy_strerror(easy_code));
+              res.at(i) = 400;
+            }
+            curl_multi_remove_handle(multi_handle_, easy_handle);
+            break;
+          }
+        }
+      }
+    }
+    return res;
+  }
+
+ private:
+  CURLM* multi_handle_;
+};
+
+static bool setup_handle_for_post(CurlHandle* handle, const std::string& url,
+                                  const rapidjson::Document& doc) {
+  rapidjson::StringBuffer buffer;
+  auto payload = JsonGetString(buffer, doc);
+  auto size = std::strlen(payload);
+  auto headers = std::make_unique<CurlHeaders>();
+  headers->append(kJsonType);
+  headers->append(kGzipEncoding);
+
+  auto compressed_size = compressBound(size) + 16;
+  auto compressed_payload =
+      std::unique_ptr<Bytef[]>(new Bytef[compressed_size]);
+  auto compress_res =
+      gzip_compress(compressed_payload.get(), &compressed_size,
+                    reinterpret_cast<const Bytef*>(payload), size);
+  if (compress_res != Z_OK) {
+    Logger()->error(
+        "Failed to compress payload: {}, while posting to {} - uncompressed "
+        "size: {}",
+        compress_res, url, size);
+    return false;
+  }
+
+  auto logger = Logger();
+  handle->set_url(url);
+  handle->set_headers(std::move(headers));
+  handle->post_payload(compressed_payload.get(), size);
+  return true;
+}
+
+std::vector<int> http::post_batches(
+    const std::string& url, const std::vector<rapidjson::Document>& batches) {
+  CurlMultiHandle multi_handle;
+
+  std::vector<std::unique_ptr<CurlHandle>> easy_handles;
+  for (const auto& doc : batches) {
+    auto handle = std::make_unique<CurlHandle>();
+    handle->set_read_timeout(read_timeout_);
+    handle->set_connect_timeout(connect_timeout_);
+    setup_handle_for_post(handle.get(), url, doc);
+    easy_handles.push_back(std::move(handle));
+  }
+
+  return multi_handle.perform_all(easy_handles);
 }
 
 void http::global_init() noexcept { curl_global_init(CURL_GLOBAL_ALL); }

--- a/util/http.h
+++ b/util/http.h
@@ -25,6 +25,7 @@ class http {
 
   int post(const std::string& url, const rapidjson::Document& payload) const;
 
+  std::vector<int> post_batches(const std::string& url, const std::vector<rapidjson::Document>& batches);
   static void global_init() noexcept;
   static void global_shutdown() noexcept;
 


### PR DESCRIPTION
This fixes #29 by adding a config option (default false) to specify
whether to send batches in parallel. We use the curl multi interface so
no extra threads are needed, but more memory will be used compared to
just sending one batch at a time.