### PR TITLE
Add support for test coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,25 @@
 language: cpp
 dist: trusty
 sudo: false
-script: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=RELWITHDEBINFO -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .. && make && ./runtests
+script: ./run-build.sh
 compiler:
   - clang
   - gcc
+
+addons:
+  apt:
+    packages:
+      - lcov
+
+after_success:
+  # Creating report
+  - cd ${TRAVIS_BUILD_DIR}
+  - lcov --directory . --capture --output-file coverage.info # capture coverage info
+  - lcov --remove coverage.info '/usr/*' '*/usr/*' '*/3rd-party/*' --output-file coverage.info # filter out system and 3rd-party stuff
+  - lcov --list coverage.info #debug info
+  # Uploading report to CodeCov
+  - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+
+env:
+  global:
+    - LANG="en_US.UTF-8"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ set(PROJECT_NAME_STR libatlasclient)
 set(CMAKE_MACOSX_RPATH 1)
 project(${PROJECT_NAME_STR})
 
+set(CMAKE_CXX_STANDARD 11)
+
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMakeModules)
+include(CodeCoverage)
+setup_target_for_coverage(${PROJECT_NAME}_coverage runtests coverage)
+
 include_directories(3rd-party ${CMAKE_CURRENT_BINARY_DIR})
 add_executable(gen_perc_bucket_tags ./gen_perc_bucket_tags.cc)
 add_executable(gen_perc_bucket_values ./gen_perc_bucket_values.cc)
@@ -49,7 +55,7 @@ add_library(atlasclient SHARED ${LIB_SOURCE_FILES}
 
 set_target_properties(atlasclient PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wno-missing-braces")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCURL_STATICLIB -Werror -fno-rtti -Wall -Wno-missing-braces -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCURL_STATICLIB -Werror -fno-rtti -Wall -Wno-missing-braces -fprofile-arcs -ftest-coverage")
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   configure_file(${CMAKE_SOURCE_DIR}/bundle/libcurl-linux.a libcurl.a COPYONLY)
@@ -112,3 +118,4 @@ if(RUN_BENCHMARKS STREQUAL "ON")
   add_executable(runbench ${BENCH_SOURCE_FILES})
   target_link_libraries(runbench atlasclient pthread benchmark)
 endif()
+

--- a/CMakeModules/CodeCoverage.cmake
+++ b/CMakeModules/CodeCoverage.cmake
@@ -1,0 +1,197 @@
+# Copyright (c) 2012 - 2015, Lars Bilke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+#
+# 2012-01-31, Lars Bilke
+# - Enable Code Coverage
+#
+# 2013-09-17, Joakim Söderberg
+# - Added support for Clang.
+# - Some additional usage instructions.
+#
+# USAGE:
+
+# 0. (Mac only) If you use Xcode 5.1 make sure to patch geninfo as described here:
+#      http://stackoverflow.com/a/22404544/80480
+#
+# 1. Copy this file into your cmake modules path.
+#
+# 2. Add the following line to your CMakeLists.txt:
+#      INCLUDE(CodeCoverage)
+#
+# 3. Set compiler flags to turn off optimization and enable coverage:
+#    SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+#   SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+#
+# 3. Use the function SETUP_TARGET_FOR_COVERAGE to create a custom make target
+#    which runs your test executable and produces a lcov code coverage report:
+#    Example:
+#   SETUP_TARGET_FOR_COVERAGE(
+#        my_coverage_target  # Name for custom target.
+#        test_driver         # Name of the test driver executable that runs the tests.
+#                  # NOTE! This should always have a ZERO as exit code
+#                  # otherwise the coverage generation will not complete.
+#        coverage            # Name of output directory.
+#        )
+#
+# 4. Build a Debug build:
+#   cmake -DCMAKE_BUILD_TYPE=Debug ..
+#   make
+#   make my_coverage_target
+#
+#
+
+# Check prereqs
+FIND_PROGRAM( GCOV_PATH gcov )
+FIND_PROGRAM( LCOV_PATH lcov )
+FIND_PROGRAM( GENHTML_PATH genhtml )
+FIND_PROGRAM( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
+
+IF(NOT GCOV_PATH)
+  MESSAGE(FATAL_ERROR "gcov not found! Aborting...")
+ENDIF() # NOT GCOV_PATH
+
+IF("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
+  IF("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 3)
+    MESSAGE(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
+  ENDIF()
+ELSEIF(NOT CMAKE_COMPILER_IS_GNUCXX)
+  MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+ENDIF() # CHECK VALID COMPILER
+
+SET(CMAKE_CXX_FLAGS_COVERAGE
+    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+    CACHE STRING "Flags used by the C++ compiler during coverage builds."
+    FORCE )
+SET(CMAKE_C_FLAGS_COVERAGE
+    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+    CACHE STRING "Flags used by the C compiler during coverage builds."
+    FORCE )
+SET(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used for linking binaries during coverage builds."
+    FORCE )
+SET(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used by the shared libraries linker during coverage builds."
+    FORCE )
+MARK_AS_ADVANCED(
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE
+    CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
+
+IF ( NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Coverage"))
+  MESSAGE( WARNING "Code coverage results with an optimized (non-Debug) build may be misleading" )
+ENDIF() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
+
+
+# Param _targetname     The name of new the custom make target
+# Param _testrunner     The name of the target which runs the tests.
+#            MUST return ZERO always, even on errors.
+#            If not, no coverage report will be created!
+# Param _outputname     lcov output is generated as _outputname.info
+#                       HTML report is generated in _outputname/index.html
+# Optional fourth parameter is passed as arguments to _testrunner
+#   Pass them in list form, e.g.: "-j;2" for -j 2
+FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
+
+  IF(NOT LCOV_PATH)
+    MESSAGE(FATAL_ERROR "lcov not found! Aborting...")
+  ENDIF() # NOT LCOV_PATH
+
+  IF(NOT GENHTML_PATH)
+    MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
+  ENDIF() # NOT GENHTML_PATH
+
+  SET(coverage_info "${CMAKE_BINARY_DIR}/${_outputname}.info")
+  SET(coverage_cleaned "${coverage_info}.cleaned")
+
+  SEPARATE_ARGUMENTS(test_command UNIX_COMMAND "${_testrunner}")
+
+  # Setup target
+  ADD_CUSTOM_TARGET(${_targetname}
+
+    # Cleanup lcov
+    ${LCOV_PATH} --directory . --zerocounters
+
+    # Run tests
+    COMMAND ${test_command} ${ARGV3}
+
+    # Capturing lcov counters and generating report
+    COMMAND ${LCOV_PATH} --directory . --capture --output-file ${coverage_info}
+    COMMAND ${LCOV_PATH} --remove ${coverage_info} 'tests/*' '/usr/*' --output-file ${coverage_cleaned}
+    COMMAND ${GENHTML_PATH} -o ${_outputname} ${coverage_cleaned}
+    COMMAND ${CMAKE_COMMAND} -E remove ${coverage_info} ${coverage_cleaned}
+
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+  )
+
+  # Show info where to find the report
+  ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
+    COMMAND ;
+    COMMENT "Open ./${_outputname}/index.html in your browser to view the coverage report."
+  )
+
+ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE
+
+# Param _targetname     The name of new the custom make target
+# Param _testrunner     The name of the target which runs the tests
+# Param _outputname     cobertura output is generated as _outputname.xml
+# Optional fourth parameter is passed as arguments to _testrunner
+#   Pass them in list form, e.g.: "-j;2" for -j 2
+FUNCTION(SETUP_TARGET_FOR_COVERAGE_COBERTURA _targetname _testrunner _outputname)
+
+  IF(NOT PYTHON_EXECUTABLE)
+    MESSAGE(FATAL_ERROR "Python not found! Aborting...")
+  ENDIF() # NOT PYTHON_EXECUTABLE
+
+  IF(NOT GCOVR_PATH)
+    MESSAGE(FATAL_ERROR "gcovr not found! Aborting...")
+  ENDIF() # NOT GCOVR_PATH
+
+  ADD_CUSTOM_TARGET(${_targetname}
+
+    # Run tests
+    ${_testrunner} ${ARGV3}
+
+    # Running gcovr
+    COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR} -e '${CMAKE_SOURCE_DIR}/tests/'  -o ${_outputname}.xml
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Running gcovr to produce Cobertura code coverage report."
+  )
+
+  # Show info where to find the report
+  ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
+    COMMAND ;
+    COMMENT "Cobertura code coverage report saved in ${_outputname}.xml."
+  )
+
+ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE_COBERTURA

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
+[![Build Status](https://travis-ci.org/Netflix-Skunkworks/atlas-native-client.svg?branch=master)](https://travis-ci.org/Netflix-Skunkworks/atlas-native-client)
+
 # Atlas Client Native Library
 
 ## Building
 
 ```
-mkdir build
-cd build
-cmake ..
+./run-build.sh
 ```
 ### To run tests:
 ```
-./runtests
+./build/runtests
 ```
 

--- a/run-build.sh
+++ b/run-build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+
+RED='\033[0;31m' # Red
+BB='\033[0;34m'  # Blue
+NC='\033[0m' # No Color
+BG='\033[0;32m' # Green
+
+error() { >&2 echo -e "${RED}$1${NC}"; }
+showinfo() { echo -e "${BG}$1${NC}"; }
+workingprocess() { echo -e "${BB}$1${NC}"; }
+allert () { echo -e "${RED}$1${NC}"; }
+
+# Building project
+mkdir -p build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+make -j8
+# Checks if last comand didn't output 0
+# $? checks what last command outputed
+# If output is 0 then command is succesfuly executed
+# If command fails it outputs number between 0 to 255
+if [ $? -ne 0 ]; then
+    error "Error: there are compile errors!"
+	# Terminate script and outputs 3
+    exit 3
+fi
+
+showinfo "Running tests ..."
+make -j8 libatlasclient_coverage
+ctest
+if [ $? -ne 0 ]; then
+    error "Error: there are failed tests!"
+    exit 4
+fi
+
+workingprocess "All tests compile and pass."
+


### PR DESCRIPTION
Fixes #37. Currently we're doing a matrix build compiling for both g++
and clang++ and doing code coverage on both (meaning both are debug
builds with no optimizations). A refinement would be to do
it on only one of them, and do a release build for the other to verify
that the tests pass with optimizations as well.