### PR TITLE
Add codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null
+ignore:
+  - "3rd-party/**/*"


### PR DESCRIPTION
Ignore 3rd-party libraries in our source tree. Try to configure
comments, although comments might not work until github integration
with codecov is configured.