### PR TITLE
Add test cases for Bucket* meters

### DIFF
--- a/test/bucket_counter_test.cc
+++ b/test/bucket_counter_test.cc
@@ -1,0 +1,46 @@
+#include "../meter/bucket_counter.h"
+#include "../util/logger.h"
+#include "test_registry.h"
+#include <gtest/gtest.h>
+
+using atlas::meter::BucketCounter;
+using atlas::meter::Measurement;
+using atlas::meter::Tag;
+using atlas::meter::bucket_functions::Age;
+using atlas::meter::kEmptyTags;
+using atlas::util::Logger;
+using std::chrono::microseconds;
+
+TEST(BucketCounter, Init) {
+  TestRegistry r;
+
+  auto id = r.CreateId("test", kEmptyTags);
+  BucketCounter b(&r, id, Age(microseconds{100}));
+  Logger()->info("BucketCounter: {}", b);
+
+  auto ms = r.AllMeasurements();
+  EXPECT_EQ(ms.size(), 0);
+}
+
+// micros to nanos
+static constexpr int64_t kMicrosToNanos = 1000l;
+TEST(BucketCounter, Record) {
+  TestRegistry r;
+  r.SetWall(1000);
+
+  auto id = r.CreateId("test", kEmptyTags);
+  BucketCounter b(&r, id, Age(microseconds{100}));
+  b.Record(30 * kMicrosToNanos);
+
+  r.SetWall(61000);
+  auto ms = r.AllMeasurements();
+  EXPECT_EQ(ms.size(), 1);
+
+  auto m = ms.front();
+
+  auto expected_id = id->WithTag(atlas::meter::statistic::count)
+                         ->WithTag(Tag::of("bucket", "050us"));
+  auto expected_value = 1 / 60.0;
+  EXPECT_EQ(*expected_id, *m.id);
+  EXPECT_DOUBLE_EQ(expected_value, m.value);
+}

--- a/test/bucket_dist_summary_test.cc
+++ b/test/bucket_dist_summary_test.cc
@@ -1,0 +1,64 @@
+#include "../meter/bucket_distribution_summary.h"
+#include "../util/logger.h"
+#include "test_registry.h"
+#include <gtest/gtest.h>
+
+using atlas::meter::BucketDistributionSummary;
+using atlas::meter::Measurement;
+using atlas::meter::Tag;
+using atlas::meter::bucket_functions::Age;
+using atlas::meter::kEmptyTags;
+using atlas::util::Logger;
+using std::chrono::seconds;
+
+TEST(BucketDistributionSummary, Init) {
+  TestRegistry r;
+
+  auto id = r.CreateId("test", kEmptyTags);
+  BucketDistributionSummary ds(&r, id, Age(seconds{60}));
+  Logger()->info("Created: {}", ds);
+
+  auto ms = r.AllMeasurements();
+  EXPECT_EQ(ms.size(), 0);
+}
+
+// seconds to nanos
+static constexpr int64_t kSecsToNanos = 1000l * 1000l * 1000l;
+
+TEST(BucketDistributionSummary, Record) {
+  TestRegistry r;
+  r.SetWall(1000);
+
+  auto id = r.CreateId("test", kEmptyTags);
+  BucketDistributionSummary ds(&r, id, Age(seconds{60}));
+  ds.Record(30 * kSecsToNanos);
+  ds.Record(22 * kSecsToNanos);
+
+  r.SetWall(61000);
+  auto ms = r.AllMeasurements();
+  EXPECT_EQ(ms.size(), 4);
+
+  auto base_id = id->WithTag(Tag::of("bucket", "30s"));
+  for (const auto& m : ms) {
+    EXPECT_EQ(60000, m.timestamp);
+
+    if (*m.id == *base_id->WithTag(atlas::meter::statistic::count)) {
+      EXPECT_DOUBLE_EQ(2 / 60.0, m.value);
+    } else if (*m.id ==
+               *base_id->WithTag(atlas::meter::statistic::totalAmount)) {
+      auto total = 30 * kSecsToNanos + 22 * kSecsToNanos;
+      EXPECT_DOUBLE_EQ(total / 60.0, m.value);
+    } else if (*m.id ==
+               *base_id->WithTag(atlas::meter::statistic::totalOfSquares)) {
+      auto totalSq = 30.0 * kSecsToNanos * 30.0 * kSecsToNanos +
+                     22.0 * kSecsToNanos * 22.0 * kSecsToNanos;
+      EXPECT_DOUBLE_EQ(totalSq / 60.0, m.value);
+    } else if (*m.id ==
+               *base_id->WithTag(atlas::meter::statistic::max)
+                    ->WithTag(Tag::of("atlas.dstype", "gauge"))) {
+      EXPECT_DOUBLE_EQ(30 * kSecsToNanos, m.value);
+    } else {
+      FAIL() << "Unknown id: " << *m.id;
+    }
+  }
+}

--- a/test/bucket_timer_test.cc
+++ b/test/bucket_timer_test.cc
@@ -1,0 +1,62 @@
+#include "../meter/bucket_timer.h"
+#include "../util/logger.h"
+#include "test_registry.h"
+#include <gtest/gtest.h>
+
+using atlas::meter::BucketTimer;
+using atlas::meter::Measurement;
+using atlas::meter::Tag;
+using atlas::meter::bucket_functions::Age;
+using atlas::meter::kEmptyTags;
+using atlas::util::Logger;
+using std::chrono::milliseconds;
+
+TEST(BucketTimer, Init) {
+  TestRegistry r;
+
+  auto id = r.CreateId("test", kEmptyTags);
+  BucketTimer t(&r, id, Age(milliseconds{100}));
+  Logger()->info("Created: {}", t);
+
+  auto ms = r.AllMeasurements();
+  EXPECT_EQ(ms.size(), 0);
+}
+
+static constexpr auto kMillisToSecs = 1 / 1000.0;
+
+TEST(BucketTimer, Record) {
+  TestRegistry r;
+  r.SetWall(1000);
+
+  auto id = r.CreateId("test", kEmptyTags);
+  BucketTimer ds(&r, id, Age(milliseconds{100}));
+  ds.Record(milliseconds(30));
+  ds.Record(milliseconds(28));
+
+  r.SetWall(61000);
+  auto ms = r.AllMeasurements();
+  EXPECT_EQ(ms.size(), 4);
+
+  auto base_id = id->WithTag(Tag::of("bucket", "050ms"));
+  for (const auto& m : ms) {
+    EXPECT_EQ(60000, m.timestamp);
+
+    if (*m.id == *base_id->WithTag(atlas::meter::statistic::count)) {
+      EXPECT_DOUBLE_EQ(2 / 60.0, m.value);
+    } else if (*m.id == *base_id->WithTag(atlas::meter::statistic::totalTime)) {
+      auto total = 30 * kMillisToSecs + 28 * kMillisToSecs;
+      EXPECT_DOUBLE_EQ(total / 60.0, m.value);
+    } else if (*m.id ==
+               *base_id->WithTag(atlas::meter::statistic::totalOfSquares)) {
+      auto totalSq = 30.0 * kMillisToSecs * 30.0 * kMillisToSecs +
+                     28.0 * kMillisToSecs * 28.0 * kMillisToSecs;
+      EXPECT_DOUBLE_EQ(totalSq / 60.0, m.value);
+    } else if (*m.id ==
+               *base_id->WithTag(atlas::meter::statistic::max)
+                    ->WithTag(Tag::of("atlas.dstype", "gauge"))) {
+      EXPECT_DOUBLE_EQ(30 * kMillisToSecs, m.value);
+    } else {
+      FAIL() << "Unknown id: " << *m.id;
+    }
+  }
+}


### PR DESCRIPTION
Looking at the code coverage report we didn't have any tests for the
bucket meters.