### PR TITLE
Remove noise from tests

### DIFF
--- a/test/bucket_counter_test.cc
+++ b/test/bucket_counter_test.cc
@@ -16,7 +16,6 @@ TEST(BucketCounter, Init) {
 
   auto id = r.CreateId("test", kEmptyTags);
   BucketCounter b(&r, id, Age(microseconds{100}));
-  Logger()->info("BucketCounter: {}", b);
 
   auto ms = r.AllMeasurements();
   EXPECT_EQ(ms.size(), 0);

--- a/test/bucket_dist_summary_test.cc
+++ b/test/bucket_dist_summary_test.cc
@@ -16,8 +16,6 @@ TEST(BucketDistributionSummary, Init) {
 
   auto id = r.CreateId("test", kEmptyTags);
   BucketDistributionSummary ds(&r, id, Age(seconds{60}));
-  Logger()->info("Created: {}", ds);
-
   auto ms = r.AllMeasurements();
   EXPECT_EQ(ms.size(), 0);
 }

--- a/test/bucket_timer_test.cc
+++ b/test/bucket_timer_test.cc
@@ -16,8 +16,6 @@ TEST(BucketTimer, Init) {
 
   auto id = r.CreateId("test", kEmptyTags);
   BucketTimer t(&r, id, Age(milliseconds{100}));
-  Logger()->info("Created: {}", t);
-
   auto ms = r.AllMeasurements();
   EXPECT_EQ(ms.size(), 0);
 }


### PR DESCRIPTION
Remove some excessively verbose log messages from some
tests