### PR TITLE
Simplify Configuration Management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,9 +93,10 @@ set_target_properties(runtests PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -Wno
 
 add_library(gtest 3rd-party/src/gtest/gtest-all.cc)
 
-configure_file(test/resources/metadata.json metadata.json COPYONLY)
-configure_file(test/resources/subs1.json subs1.json COPYONLY)
-configure_file(test/resources/many-subs.json many-subs.json COPYONLY)
+
+add_custom_command(TARGET runtests POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/test/resources $<TARGET_FILE_DIR:runtests>/resources)
 
 target_link_libraries(runtests
         atlasclient

--- a/atlas_client.cc
+++ b/atlas_client.cc
@@ -109,7 +109,7 @@ util::Config GetConfig() {
   if (atlas_client) {
     return *atlas_client->GetConfig();
   }
-  return *atlas::util::DefaultConfig();
+  return util::Config();
 }
 
 void PushMeasurements(const atlas::meter::Measurements& measurements) {
@@ -120,10 +120,6 @@ void PushMeasurements(const atlas::meter::Measurements& measurements) {
 
 void SetLoggingDirs(const std::vector<std::string>& dirs) {
   atlas::util::SetLoggingDirs(dirs);
-}
-
-void SetLogSizes(size_t max_size, size_t max_files) {
-  atlas::util::SetLogSizes({max_size, max_files});
 }
 
 void UseConsoleLogger(int level) { atlas::util::UseConsoleLogger(level); }

--- a/run-build.sh
+++ b/run-build.sh
@@ -39,7 +39,7 @@ if [ $CC = gcc ]; then
   make -j8 libatlasclient_coverage
 fi
 
-ctest
+./runtests
 if [ $? -ne 0 ]; then
     error "Error: there are failed tests!"
     exit 4

--- a/test/config_manager_test.cc
+++ b/test/config_manager_test.cc
@@ -1,0 +1,19 @@
+#include "../util/config_manager.h"
+#include <gtest/gtest.h>
+#include <thread>
+
+using atlas::util::ConfigManager;
+
+TEST(ConfigManager, Init) {
+  ConfigManager cm("./resources/config.json", 1);
+  auto cfg = cm.GetConfig();
+  EXPECT_TRUE(cfg->ShouldForceStart());
+  EXPECT_FALSE(cfg->ShouldNotifyAlertServer());
+
+  const auto& endpoints = cfg->EndpointConfiguration();
+  EXPECT_EQ(endpoints.publish, "http://atlas.example.com/pub");
+  EXPECT_EQ(endpoints.evaluate, "http://atlas.example.com/eval");
+  EXPECT_EQ(endpoints.subscriptions, "http://atlas.example.com/subs");
+  EXPECT_EQ(endpoints.check_cluster, "http://atlas.example.com/check");
+}
+

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -1,27 +1,177 @@
-#include "../util/config_manager.h"
+#include "../util/config.h"
 #include <gtest/gtest.h>
+#include <rapidjson/document.h>
+#include <cstdlib>
 
-using atlas::util::DefaultConfig;
+using atlas::util::Config;
+using atlas::util::EndpointConfig;
+using atlas::util::FeaturesConfig;
+using atlas::util::HttpConfig;
+using atlas::util::LogConfig;
 using atlas::util::intern_str;
-using std::make_pair;
-using std::map;
-using std::string;
+
+TEST(Config, Default) {
+  auto cfg = Config();
+  EXPECT_TRUE(cfg.IsMainEnabled());
+}
+
+TEST(Config, SetNotify) {
+  auto cfg = Config();
+  cfg.SetNotify(false);
+  EXPECT_FALSE(cfg.ShouldNotifyAlertServer());
+  cfg.SetNotify(true);
+  EXPECT_TRUE(cfg.ShouldNotifyAlertServer());
+}
+
+TEST(Config, ParseConfig) {
+  const char* disabledMain = "{\"publishEnabled\": false}";
+  rapidjson::Document document;
+  document.Parse(disabledMain);
+  auto cfg = Config::FromJson(document, Config());
+  EXPECT_FALSE(cfg->IsMainEnabled());
+}
+
+TEST(LogConfig, ParseAndCompose) {
+  const char* cfgStr = R"json(
+      {"logVerbosity": 1,
+       "logMaxSize": 1000,
+       "logMaxFiles": 42,
+       "dumpMetrics": true,
+       "dumpSubscriptions": true
+      })json";
+  rapidjson::Document document;
+  document.Parse(cfgStr);
+
+  auto check_cfg = [](const LogConfig& cfg) {
+    EXPECT_EQ(cfg.verbosity, 1);
+    EXPECT_EQ(cfg.max_files, 42);
+    EXPECT_EQ(cfg.max_size, 1000);
+    EXPECT_TRUE(cfg.dump_subscriptions);
+    EXPECT_TRUE(cfg.dump_metrics);
+  };
+
+  auto cfg = LogConfig::FromJson(document, LogConfig());
+  check_cfg(cfg);
+
+  // check that we expose and parse the right subconfig
+  auto c = Config::FromJson(document, Config());
+  auto cfg2 = c->LogConfiguration();
+  check_cfg(cfg2);
+}
+
+TEST(HttpConfig, ParseAndCompose) {
+  const char* cfgStr = R"json(
+      {"connectTimeout": 10,
+       "readTimeout": 11,
+       "sendInParallel": true,
+       "batchSize": 42
+      })json";
+  rapidjson::Document document;
+  document.Parse(cfgStr);
+  auto cfg = HttpConfig::FromJson(document, HttpConfig());
+  auto check_cfg = [](const HttpConfig& cfg) {
+    EXPECT_EQ(cfg.connect_timeout, 10);
+    EXPECT_EQ(cfg.read_timeout, 11);
+    EXPECT_EQ(cfg.batch_size, 42);
+    EXPECT_TRUE(cfg.send_in_parallel);
+  };
+
+  check_cfg(cfg);
+  // check that we expose and parse the right subconfig
+  auto c = Config::FromJson(document, Config());
+  auto cfg2 = c->HttpConfiguration();
+  check_cfg(cfg2);
+}
+
+TEST(EndpointConfig, ParseAndCompose) {
+  setenv("EndpointConfigTest", "abcdef", 1);
+  const char* cfgStr = R"json(
+      {"evaluateUrl": "http://foo.$EndpointConfigTest.bar/eval",
+       "subscriptionsUrl": "http://foo.$EndpointConfigTest.bar/subs",
+       "publishUrl": "http://foo.$EndpointConfigTest.bar/pub",
+       "checkClusterUrl": "http://foo.$EndpointConfigTest.bar/check"
+      })json";
+  rapidjson::Document document;
+  document.Parse(cfgStr);
+  auto cfg = EndpointConfig::FromJson(document, EndpointConfig());
+  auto check_cfg = [](const EndpointConfig& cfg) {
+    EXPECT_EQ(cfg.evaluate, "http://foo.abcdef.bar/eval");
+    EXPECT_EQ(cfg.subscriptions, "http://foo.abcdef.bar/subs");
+    EXPECT_EQ(cfg.publish, "http://foo.abcdef.bar/pub");
+    EXPECT_EQ(cfg.check_cluster, "http://foo.abcdef.bar/check");
+  };
+  check_cfg(cfg);
+
+  // check that we expose and parse the right subconfig
+  auto c = Config::FromJson(document, Config());
+  auto cfg2 = c->EndpointConfiguration();
+  check_cfg(cfg2);
+}
+
+TEST(Features, Parse) {
+  const char* cfgStr = R"json(
+      {"validateMetrics": false,
+       "notifyAlertServer": false,
+       "publishConfig": ["class,:has,:all", ":true,(,nf.node,),:drop-tags"],
+       "forceStart": true,
+       "publishEnabled": true,
+       "subscriptionsEnabled": true,
+       "subscriptionsRefreshMillis": 1234
+      })json";
+  rapidjson::Document document;
+  document.Parse(cfgStr);
+  auto cfg = FeaturesConfig::FromJson(document, FeaturesConfig());
+  EXPECT_FALSE(cfg.validate);
+  EXPECT_FALSE(cfg.notify_alert_server);
+  EXPECT_TRUE(cfg.force_start);
+  EXPECT_TRUE(cfg.main);
+  EXPECT_TRUE(cfg.subscriptions);
+  EXPECT_EQ(cfg.subscription_refresh_ms, 1234);
+  auto expected_pub_config = std::vector<std::string>{
+      "class,:has,:all", ":true,(,nf.node,),:drop-tags"};
+  EXPECT_EQ(cfg.publish_config, expected_pub_config);
+
+  auto cfg2 = Config::FromJson(document, Config());
+  EXPECT_FALSE(cfg2->ShouldValidateMetrics());
+  EXPECT_FALSE(cfg2->ShouldNotifyAlertServer());
+  EXPECT_EQ(cfg2->PublishConfig(), expected_pub_config);
+  EXPECT_TRUE(cfg2->IsMainEnabled());
+  EXPECT_TRUE(cfg2->AreSubsEnabled());
+  EXPECT_EQ(cfg2->SubRefreshMillis(), 1234);
+}
+
+TEST(Config, ToString) {
+  const char* sample_cfg = R"json(
+      {"publishEnabled": false,
+       "subscriptionsEnabled": true,
+       "subscriptionsRefreshMillis": 42
+      })json";
+  rapidjson::Document document;
+  document.Parse(sample_cfg);
+
+  auto cfg = Config::FromJson(document, Config());
+  auto str = cfg->ToString();
+  constexpr auto not_found = std::string::npos;
+  EXPECT_TRUE(str.find("mainEnabled=false") != not_found);
+  EXPECT_TRUE(str.find("subsEnabled=true") != not_found);
+  EXPECT_TRUE(str.find("subsRefresh=42") != not_found);
+}
 
 TEST(Config, LoggingDirectory) {
-  auto cfg = DefaultConfig();
+  auto cfg = Config();
   // running tests we set the logger to stderr, so it should be empty.
-  EXPECT_TRUE(cfg->LoggingDirectory().empty());
+  EXPECT_TRUE(cfg.LoggingDirectory().empty());
 }
 
 TEST(Config, AddCommonTag) {
-  auto cfg = DefaultConfig();
-  auto orig_common_tags = cfg->CommonTags();
+  auto cfg = Config();
+  auto orig_common_tags = cfg.CommonTags();
 
   atlas::meter::Tags new_tags;
   new_tags.add("foo", "bar");
-  cfg->AddCommonTags(new_tags);
+  cfg.AddCommonTags(new_tags);
 
-  auto new_common_tags = cfg->CommonTags();
+  auto new_common_tags = cfg.CommonTags();
   auto new_key_ref = intern_str("foo");
   auto new_val_ref = intern_str("bar");
   EXPECT_EQ(new_val_ref, new_common_tags.at(new_key_ref));

--- a/test/http_test.cc
+++ b/test/http_test.cc
@@ -14,6 +14,7 @@
 #include "../interpreter/tags_value.h"
 #include <thread>
 
+using atlas::util::HttpConfig;
 using atlas::util::Logger;
 using atlas::util::ToLowerCopy;
 
@@ -236,8 +237,8 @@ TEST(HttpTest, Post) {
   auto logger = Logger();
   logger->info("Server started on port {}", port);
 
-  auto cfg = atlas::util::DefaultConfig();
-  http client{*cfg};
+  auto cfg = HttpConfig();
+  http client{cfg};
   std::ostringstream os;
   os << "http://localhost:" << port << "/foo";
   auto url = os.str();
@@ -308,8 +309,8 @@ TEST(HttpTest, PostBatches) {
   auto logger = Logger();
   logger->info("Server started on port {}", port);
 
-  auto cfg = atlas::util::DefaultConfig();
-  http client{*cfg};
+  auto cfg = HttpConfig();
+  http client{cfg};
   std::ostringstream os;
   os << "http://localhost:" << port << "/foo";
   auto url = os.str();
@@ -352,8 +353,8 @@ TEST(HttpTest, Timeout) {
   auto logger = Logger();
   logger->info("Server started on port {}", port);
 
-  auto cfg = atlas::util::DefaultConfig();
-  http client{*cfg};
+  auto cfg = HttpConfig();
+  http client{cfg};
   std::ostringstream os;
   os << "http://localhost:" << port << "/foo";
   auto url = os.str();

--- a/test/resources/config.json
+++ b/test/resources/config.json
@@ -1,0 +1,9 @@
+{
+  "forceStart": true,
+  "publishUrl": "http://atlas.example.com/pub",
+  "evaluateUrl": "http://atlas.example.com/eval",
+  "subscriptionsUrl": "http://atlas.example.com/subs",
+  "checkClusterUrl": "http://atlas.example.com/check",
+  "notifyAlertServer": false,
+  "dumpMetrics": true
+}

--- a/test/subscription_registry_test.cc
+++ b/test/subscription_registry_test.cc
@@ -7,15 +7,14 @@
 
 using atlas::util::Config;
 using atlas::util::ConfigManager;
-using atlas::util::DefaultConfig;
-using atlas::util::intern_str;
 using atlas::util::Logger;
+using atlas::util::intern_str;
 
-using atlas::interpreter::kNameRef;
+using atlas::interpreter::ClientVocabulary;
+using atlas::interpreter::Interpreter;
 using atlas::interpreter::TagsValuePair;
 using atlas::interpreter::TagsValuePairs;
-using atlas::interpreter::Interpreter;
-using atlas::interpreter::ClientVocabulary;
+using atlas::interpreter::kNameRef;
 using namespace atlas::meter;
 
 class SR : public SubscriptionRegistry {
@@ -78,7 +77,7 @@ TEST(SubscriptionRegistry, MainMetrics) {
 
   auto pub_config = std::vector<std::string>{
       "name,m1,:eq,:all", ":true,(,k2,nf.node,nf.region,),:drop-tags"};
-  auto cfg = DefaultConfig()->WithPublishConfig(pub_config);
+  auto cfg = Config().WithPublishConfig(pub_config);
   manual_clock.SetWall(60042);
   auto common_tags = cfg.CommonTags();
   const auto& res = registry.GetMainMeasurements(cfg, common_tags);
@@ -96,14 +95,10 @@ TEST(SubscriptionRegistry, MainMetrics) {
 
   auto ct = common_tags.size();
   auto expected_name_num_tags = std::unordered_map<std::string, size_t>(
-      {{"m1", 4u + ct},
-       {"m2", 3u + ct - 2},
-       {"m3", 3u + ct - 2}});
+      {{"m1", 4u + ct}, {"m2", 3u + ct - 2}, {"m3", 3u + ct - 2}});
   EXPECT_EQ(name_num_tags, expected_name_num_tags);
 
   auto expected_name_value = std::unordered_map<std::string, double>(
-      {{"m1", 1/60.0},
-       {"m2", 120/60.0},
-       {"m3", 120/60.0}});
+      {{"m1", 1 / 60.0}, {"m2", 120 / 60.0}, {"m3", 120 / 60.0}});
   EXPECT_EQ(name_value, expected_name_value);
 }

--- a/test/subscriptions_manager_test.cc
+++ b/test/subscriptions_manager_test.cc
@@ -20,7 +20,7 @@ rapidjson::Document SubResultsToJson(
 
 using namespace atlas::meter;
 TEST(SubscriptionsManager, ParseSubs) {
-  std::ifstream one_sub("subs1.json");
+  std::ifstream one_sub("./resources/subs1.json");
   std::stringstream buffer;
   buffer << one_sub.rdbuf();
 
@@ -35,7 +35,7 @@ TEST(SubscriptionsManager, ParseSubs) {
 }
 
 TEST(SubscriptionsManager, ParseLotsOfSubs) {
-  std::ifstream one_sub("many-subs.json");
+  std::ifstream one_sub("./resources/many-subs.json");
   std::stringstream buffer;
   buffer << one_sub.rdbuf();
 

--- a/util/config_manager.cc
+++ b/util/config_manager.cc
@@ -7,64 +7,6 @@
 
 namespace atlas {
 namespace util {
-static constexpr int64_t kRefresherMillis = 10000;
-static constexpr int kConnectTimeout = 6;
-static constexpr int kReadTimeout = 20;
-static constexpr int kBatchSize = 10000;
-static constexpr bool kValidateMetrics = true;
-
-static const char* kEvaluateUrl =
-    "http://atlas-lwcapi-iep.$EC2_REGION.iep$NETFLIX_ENVIRONMENT.netflix.net/"
-    "lwc/api/"
-    "v1/evaluate";
-static const char* kSubscriptionsUrl =
-    "http://atlas-lwcapi-iep.$EC2_REGION.iep$NETFLIX_ENVIRONMENT.netflix.net/"
-    "lwc/api/"
-    "v1/expressions/$NETFLIX_CLUSTER";
-static const char* kPublishUrl =
-    "http://"
-    "atlas-pub-$EC2_OWNER_ID.$EC2_REGION.iep$NETFLIX_ENVIRONMENT.netflix.net/"
-    "api/v1/publish-fast";
-static const char* kCheckClusterUrl =
-    "http://"
-    "atlas-alert-api-$EC2_OWNER_ID.$EC2_REGION.$NETFLIX_ENVIRONMENT.netflix."
-    "net/"
-    "alertchecker/checkCluster/$NETFLIX_CLUSTER";
-static const char* kPublishExpr = ":true,:all";
-static const char* kDefaultDisabledFile = "/mnt/data/atlas.disabled";
-
-static const std::vector<std::string> kPublishConfig{kPublishExpr};
-constexpr int kDefaultVerbosity = 2;
-
-static std::vector<std::string> vector_from(const rapidjson::Value& array) {
-  std::vector<std::string> res;
-  for (auto& v : array.GetArray()) {
-    res.emplace_back(v.GetString());
-  }
-  return res;
-}
-
-static inline void put_if_nonempty(meter::Tags* tags, const char* key,
-                                   std::string&& val) {
-  if (!val.empty()) {
-    tags->add(key, val.c_str());
-  }
-}
-
-static meter::Tags get_default_common_tags() {
-  meter::Tags common_tags_;
-  put_if_nonempty(&common_tags_, "nf.node", env::instance_id());
-  put_if_nonempty(&common_tags_, "nf.cluster", env::cluster());
-  put_if_nonempty(&common_tags_, "nf.app", env::app());
-  put_if_nonempty(&common_tags_, "nf.asg", env::asg());
-  put_if_nonempty(&common_tags_, "nf.stack", env::stack());
-  put_if_nonempty(&common_tags_, "nf.vmtype", env::vmtype());
-  put_if_nonempty(&common_tags_, "nf.task", env::taskid());
-  put_if_nonempty(&common_tags_, "nf.zone", env::zone());
-  put_if_nonempty(&common_tags_, "nf.region", env::region());
-  put_if_nonempty(&common_tags_, "nf.account", env::account());
-  return common_tags_;
-}
 
 static std::unique_ptr<Config> DocToConfig(
     const rapidjson::Document& document,
@@ -75,95 +17,7 @@ static std::unique_ptr<Config> DocToConfig(
     return defaults;
   }
 
-  std::string eval_url = document.HasMember("evaluateUrl")
-                             ? document["evaluateUrl"].GetString()
-                             : defaults->EvalEndpoint();
-
-  std::string sub_endpoint = document.HasMember("subscriptionsUrl")
-                                 ? document["subscriptionsUrl"].GetString()
-                                 : defaults->SubsEndpoint();
-
-  std::string publish_endpoint = document.HasMember("publishUrl")
-                                     ? document["publishUrl"].GetString()
-                                     : defaults->PublishEndpoint();
-
-  auto validate_metrics = document.HasMember("validateMetrics")
-                              ? document["validateMetrics"].GetBool()
-                              : defaults->ShouldValidateMetrics();
-
-  std::string check_cluster_endpoint =
-      document.HasMember("checkClusterUrl")
-          ? document["checkClusterUrl"].GetString()
-          : defaults->CheckClusterEndpoint();
-
-  auto notify_alert_server = document.HasMember("notifyAlertServer")
-                                 ? document["notifyAlertServer"].GetBool()
-                                 : defaults->ShouldNotifyAlertServer();
-
-  std::vector<std::string> publish_config =
-      document.HasMember("publishConfig")
-          ? vector_from(document["publishConfig"])
-          : defaults->PublishConfig();
-
-  auto force_start = document.HasMember("forceStart")
-                         ? document["forceStart"].GetBool()
-                         : defaults->ShouldForceStart();
-
-  auto main_enabled = document.HasMember("publishEnabled")
-                          ? document["publishEnabled"].GetBool()
-                          : defaults->IsMainEnabled();
-
-  auto subs_enabled = document.HasMember("subscriptionsEnabled")
-                          ? document["subscriptionsEnabled"].GetBool()
-                          : defaults->AreSubsEnabled();
-
-  auto dump_metrics = document.HasMember("dumpMetrics")
-                          ? document["dumpMetrics"].GetBool()
-                          : defaults->ShouldDumpMetrics();
-
-  auto dump_subscriptions = document.HasMember("dumpSubscriptions")
-                                ? document["dumpSubscriptions"].GetBool()
-                                : defaults->ShouldDumpSubs();
-
-  int64_t sub_refresh = document.HasMember("subscriptionsRefreshMillis")
-                            ? document["subscriptionsRefreshMillis"].GetInt64()
-                            : defaults->SubRefreshMillis();
-
-  auto connect_timeout = document.HasMember("connectTimeout")
-                             ? document["connectTimeout"].GetInt()
-                             : defaults->ConnectTimeout();
-
-  auto read_timeout = document.HasMember("readTimeout")
-                          ? document["readTimeout"].GetInt()
-                          : defaults->ReadTimeout();
-
-  auto batch_size = document.HasMember("batchSize")
-                        ? document["batchSize"].GetInt()
-                        : defaults->BatchSize();
-
-  auto send_in_parallel = document.HasMember("sendInParallel")
-                              ? document["sendInParallel"].GetBool()
-                              : defaults->SendInParallel();
-
-  auto log_verbosity = document.HasMember("logVerbosity")
-                           ? document["logVerbosity"].GetInt()
-                           : defaults->LogVerbosity();
-
-  auto log_max_size = document.HasMember("logMaxSize")
-                          ? document["logMaxSize"].GetUint()
-                          : defaults->LogMaxSize();
-
-  auto log_max_files = document.HasMember("logMaxFiles")
-                           ? document["logMaxFiles"].GetUint()
-                           : defaults->LogMaxFiles();
-
-  return std::make_unique<Config>(
-      defaults->DisabledFile(), eval_url, sub_endpoint, publish_endpoint,
-      validate_metrics, check_cluster_endpoint, notify_alert_server,
-      publish_config, sub_refresh, connect_timeout, read_timeout, batch_size,
-      force_start, main_enabled, subs_enabled, dump_metrics, dump_subscriptions,
-      log_verbosity, send_in_parallel, log_max_size, log_max_files,
-      get_default_common_tags());
+  return Config::FromJson(document, *defaults);
 }
 
 static std::unique_ptr<Config> ParseConfigFile(
@@ -182,48 +36,21 @@ static std::unique_ptr<Config> ParseConfigFile(
         .Parse<rapidjson::kParseCommentsFlag | rapidjson::kParseNanAndInfFlag>(
             buffer.str().c_str());
     auto cfg = DocToConfig(document, std::move(defaults));
-    Logger()->debug("Config after parsing {}: {}", file_name,
-                    ConfigToString(*cfg));
+    Logger()->debug("Config after parsing {}: {}", file_name, cfg->ToString());
     return cfg;
   }
   return defaults;
 }
 
-std::unique_ptr<Config> DefaultConfig(bool notify) noexcept {
-  const char* disabled_file = std::getenv("ATLAS_DISABLED_FILE");
-  if (disabled_file == nullptr) {
-    disabled_file = kDefaultDisabledFile;
-  }
-
-  auto log_num_size = GetLogSizes();
-  return std::make_unique<Config>(
-      disabled_file, std::string(kEvaluateUrl), std::string(kSubscriptionsUrl),
-      std::string(kPublishUrl), kValidateMetrics, std::string(kCheckClusterUrl),
-      notify,  // whether to notify alert-server about on-instance alert support
-      kPublishConfig, kRefresherMillis, kConnectTimeout, kReadTimeout,
-      kBatchSize,
-      // do not run on dev env
-      false,
-      // enable main but not subscriptions yet (need clusters in main account)
-      true, false,
-      // do not dump main or subs
-      false, false, kDefaultVerbosity,
-      // do not send metrics in parallel to reduce memory footprint used
-      false, log_num_size.max_size, log_num_size.max_files,
-      get_default_common_tags());
-}
-
 static constexpr const char* const kGlobalFile =
     "/usr/local/etc/atlas-config.json";
-static constexpr const char* const kLocalFile = "./atlas-config.json";
 
 std::unique_ptr<Config> ConfigManager::get_current_config() noexcept {
-  auto my_global = ParseConfigFile(kGlobalFile, DefaultConfig(default_notify_));
-  return ParseConfigFile(kLocalFile, std::move(my_global));
+  auto defaults = std::make_unique<Config>();
+  defaults->SetNotify(default_notify_);
+  auto my_global = ParseConfigFile(kGlobalFile, std::move(defaults));
+  return ParseConfigFile(local_file_name_, std::move(my_global));
 }
-
-ConfigManager::ConfigManager() noexcept
-    : current_config_{std::shared_ptr<Config>(get_current_config())} {}
 
 std::shared_ptr<Config> ConfigManager::GetConfig() const noexcept {
   std::lock_guard<std::mutex> lock{config_mutex};
@@ -238,7 +65,7 @@ void ConfigManager::refresher() noexcept {
       Logger()->info("Ignoring exception while refreshing configuration: {}",
                      e.what());
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(kRefresherMillis));
+    std::this_thread::sleep_for(std::chrono::milliseconds(refresh_ms_));
   }
   Logger()->info("Stopping ConfigManager");
 }
@@ -251,20 +78,14 @@ void ConfigManager::Start() noexcept {
 
 void ConfigManager::Stop() noexcept { should_run_ = false; }
 
-static void do_logging_config(const Config& config) noexcept {
-  SetLoggingLevel(config.LogVerbosity());
-  auto current = GetLogSizes();
-  auto new_size = config.LogMaxSize();
-  auto new_files = config.LogMaxFiles();
-  if (current.max_files != new_files || current.max_size != new_size) {
-    SetLogSizes({new_size, new_files});
-  }
+static void do_logging_config(const LogConfig& config) noexcept {
+  InitializeLogging(config);
 }
 
 void ConfigManager::refresh_configs() noexcept {
   auto logger = Logger();
   auto new_config = get_current_config();
-  do_logging_config(*new_config);
+  do_logging_config(new_config->LogConfiguration());
   std::lock_guard<std::mutex> lock{config_mutex};
   new_config->AddCommonTags(extra_tags_);
   current_config_ = std::move(new_config);

--- a/util/config_manager.h
+++ b/util/config_manager.h
@@ -1,21 +1,24 @@
 #pragma once
 
 #include <atomic>
-#include <rapidjson/document.h>
 #include <memory>
 #include <mutex>
 #include <string>
 #include "config.h"
-#include "environment.h"
 
 namespace atlas {
 namespace util {
 
-std::unique_ptr<Config> DefaultConfig(bool notify = true) noexcept;
+static constexpr const char* kLocalFileName = "./atlas-config.json";
+static constexpr int kConfigRefreshMillis = 10000;
 
 class ConfigManager {
  public:
-  ConfigManager() noexcept;
+  ConfigManager(std::string local_file_name = kLocalFileName,
+                int refresh_ms = kConfigRefreshMillis) noexcept
+      : local_file_name_{std::move(local_file_name)},
+        refresh_ms_{refresh_ms},
+        current_config_{std::shared_ptr<Config>(get_current_config())} {}
   ~ConfigManager() { Stop(); }
   std::shared_ptr<Config> GetConfig() const noexcept;
 
@@ -29,6 +32,8 @@ class ConfigManager {
 
  private:
   mutable std::mutex config_mutex;
+  std::string local_file_name_;
+  int refresh_ms_;
   std::shared_ptr<Config> current_config_;
   std::atomic<bool> should_run_{false};
   meter::Tags extra_tags_;
@@ -38,5 +43,5 @@ class ConfigManager {
   void refresh_configs() noexcept;
   std::unique_ptr<Config> get_current_config() noexcept;
 };
-}
-}
+}  // namespace util
+}  // namespace atlas

--- a/util/file_watcher.h
+++ b/util/file_watcher.h
@@ -19,10 +19,25 @@ class FileWatcher {
       : file_name_(other.file_name_),
         last_updated_(other.last_updated_.load(std::memory_order_relaxed)),
         exists_(other.exists_.load(std::memory_order_relaxed)) {}
+
+  FileWatcher& operator=(const FileWatcher& other) noexcept {
+    file_name_ = other.file_name_;
+    exists_.store(other.exists_, std::memory_order_relaxed);
+    last_updated_.store(other.last_updated_, std::memory_order_relaxed);
+    return *this;
+  }
+
   FileWatcher(FileWatcher&& other) noexcept
       : file_name_(std::move(other.file_name_)),
         last_updated_(other.last_updated_.load(std::memory_order_relaxed)),
         exists_(other.exists_.load(std::memory_order_relaxed)) {}
+
+  FileWatcher& operator=(FileWatcher&& other) noexcept {
+    file_name_ = std::move(other.file_name_);
+    exists_.store(other.exists_, std::memory_order_relaxed);
+    last_updated_.store(other.last_updated_, std::memory_order_relaxed);
+    return *this;
+  }
 
   bool exists() const noexcept {
     auto last = last_updated_.load(std::memory_order_relaxed);

--- a/util/http.h
+++ b/util/http.h
@@ -11,9 +11,9 @@ namespace util {
 
 class http {
  public:
-  explicit http(const Config& config)
-      : connect_timeout_(config.ConnectTimeout()),
-        read_timeout_(config.ReadTimeout()) {}
+  explicit http(const HttpConfig& config)
+      : connect_timeout_(config.connect_timeout),
+        read_timeout_(config.read_timeout) {}
 
   int conditional_get(const std::string& url, std::string& etag,
                       std::string* res) const;
@@ -25,7 +25,8 @@ class http {
 
   int post(const std::string& url, const rapidjson::Document& payload) const;
 
-  std::vector<int> post_batches(const std::string& url, const std::vector<rapidjson::Document>& batches);
+  std::vector<int> post_batches(
+      const std::string& url, const std::vector<rapidjson::Document>& batches);
   static void global_init() noexcept;
   static void global_shutdown() noexcept;
 

--- a/util/logger.h
+++ b/util/logger.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "config.h"
 #include <spdlog/spdlog.h>
 #include <vector>
 
@@ -8,16 +9,8 @@ namespace util {
 
 std::shared_ptr<spdlog::logger> Logger() noexcept;
 void UseConsoleLogger(int level) noexcept;
-void SetLoggingLevel(int level) noexcept;
 void SetLoggingDirs(const std::vector<std::string>& dirs) noexcept;
-
-struct LogNumSize {
-  size_t max_size;
-  size_t max_files;
-};
-
-void SetLogSizes(const LogNumSize& log_num_size) noexcept;
-LogNumSize GetLogSizes() noexcept;
+void InitializeLogging(const LogConfig& config) noexcept;
 std::string GetLoggingDir() noexcept;
 
 }  // namespace util

--- a/util/small_tag_map.h
+++ b/util/small_tag_map.h
@@ -51,10 +51,7 @@ static constexpr size_t kMaxTags = 32u;
 class SmallTagMap : private detail::prime_number_hash_policy {
   using value_type = std::pair<util::StrRef, util::StrRef>;
 
- public:
-  SmallTagMap() noexcept { init(); }
-
-  SmallTagMap(const SmallTagMap& other) noexcept {
+  void init_from(const SmallTagMap& other) {
     prime_index = other.prime_index;
     actual_size_ = other.actual_size_;
     auto N = num_buckets();
@@ -64,10 +61,27 @@ class SmallTagMap : private detail::prime_number_hash_policy {
     }
   }
 
-  SmallTagMap(SmallTagMap&& other) noexcept {
+  void move_from(SmallTagMap&& other) {
     prime_index = other.prime_index;
     entries_ = std::move(other.entries_);
     actual_size_ = other.actual_size_;
+  }
+
+ public:
+  SmallTagMap() noexcept { init(); }
+
+  SmallTagMap(const SmallTagMap& other) noexcept { init_from(other); }
+
+  SmallTagMap& operator=(const SmallTagMap& other) noexcept {
+    init_from(other);
+    return *this;
+  }
+
+  SmallTagMap(SmallTagMap&& other) noexcept { move_from(std::move(other)); }
+
+  SmallTagMap& operator=(SmallTagMap&& other) noexcept {
+    move_from(std::move(other));
+    return *this;
   }
 
   SmallTagMap(std::initializer_list<meter::Tag> vs) {


### PR DESCRIPTION
Split the big `Config` class into smaller, easier to understand classes:

* `LogConfig` for configuring logs and settings for debugging.

* `EndpointConfig` for setting the URLs to hit for different services.

* `HttpConfig` for configuring our HTTP client, including things like
batch sizes, and parallel sending of metrics.

* `FeatureConfig` to configure which settings are enabled, and how they
should work.

Fixes #43