### PR TITLE
Fix threading issues

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -21,8 +21,8 @@ void init_tags(Tags* tags) {
 
 int main(int argc, char* argv[]) {
   atlas::util::UseConsoleLogger(1);
-  auto logger = atlas::util::Logger();
-  InitAtlas();
+  const auto& logger = atlas::util::Logger();
+  atlas::Init();
 
   Tags test_tags;
   init_tags(&test_tags);
@@ -35,7 +35,8 @@ int main(int argc, char* argv[]) {
     logger->info("Sleeping for 40s");
     std::this_thread::sleep_for(std::chrono::seconds(40));
   }
+  logger->info("Shutting down");
 
-  ShutdownAtlas();
+  atlas::Shutdown();
   return 0;
 }

--- a/meter/subscription_manager.h
+++ b/meter/subscription_manager.h
@@ -2,6 +2,8 @@
 
 #include "../util/config_manager.h"
 #include "subscription_registry.h"
+#include <condition_variable>
+#include <mutex>
 #include <set>
 
 namespace atlas {
@@ -35,6 +37,11 @@ class SubscriptionManager {
   std::atomic<Subscriptions*> subscriptions_{nullptr};
   SubscriptionRegistry& registry_;
   std::atomic<bool> should_run_{false};
+  std::thread main_sender_thread;
+  std::thread sub_refresher_thread;
+  std::vector<std::thread> sub_senders;
+  std::mutex mutex;
+  std::condition_variable cv;
 
   void SubRefresher() noexcept;
   void MainSender(std::chrono::seconds initial_delay) noexcept;

--- a/test/config_manager_test.cc
+++ b/test/config_manager_test.cc
@@ -16,4 +16,3 @@ TEST(ConfigManager, Init) {
   EXPECT_EQ(endpoints.subscriptions, "http://atlas.example.com/subs");
   EXPECT_EQ(endpoints.check_cluster, "http://atlas.example.com/check");
 }
-

--- a/test/http_test.cc
+++ b/test/http_test.cc
@@ -31,6 +31,7 @@ class http_server {
   ~http_server() {
     if (sockfd_ >= 0) {
       close(sockfd_);
+      acceptor.join();
     }
   }
 
@@ -55,8 +56,7 @@ class http_server {
     ASSERT_TRUE(getsockname(sockfd_, (sockaddr*)&serv_addr, &serv_len) >= 0);
     port_ = ntohs(serv_addr.sin_port);
 
-    std::thread acceptor([this] { accept_loop(); });
-    acceptor.detach();
+    acceptor = std::thread([this] { accept_loop(); });
   }
 
   int get_port() const { return port_; };
@@ -98,6 +98,7 @@ class http_server {
   const std::vector<Request>& get_requests() const { return requests_; };
 
  private:
+  std::thread acceptor;
   int sockfd_ = -1;
   int port_ = 0;
   std::atomic<bool> is_done{false};

--- a/test/http_test.cc
+++ b/test/http_test.cc
@@ -31,7 +31,6 @@ class http_server {
   ~http_server() {
     if (sockfd_ >= 0) {
       close(sockfd_);
-      acceptor.join();
     }
   }
 
@@ -56,7 +55,8 @@ class http_server {
     ASSERT_TRUE(getsockname(sockfd_, (sockaddr*)&serv_addr, &serv_len) >= 0);
     port_ = ntohs(serv_addr.sin_port);
 
-    acceptor = std::thread([this] { accept_loop(); });
+    std::thread acceptor([this] { accept_loop(); });
+    acceptor.detach();
   }
 
   int get_port() const { return port_; };
@@ -98,7 +98,6 @@ class http_server {
   const std::vector<Request>& get_requests() const { return requests_; };
 
  private:
-  std::thread acceptor;
   int sockfd_ = -1;
   int port_ = 0;
   std::atomic<bool> is_done{false};

--- a/test/small_tag_map_test.cc
+++ b/test/small_tag_map_test.cc
@@ -49,16 +49,17 @@ TEST(SmallTagMap, Get) {
 TEST(SmallTagMap, AddAll) {
   auto map1 = SmallTagMap{{"k1", "v1"}, {"k2", "v2"}};
   auto map2 = SmallTagMap{{"k3", "v1"}, {"k4", "v2"}};
-  auto expected = SmallTagMap{{"k1", "v1"}, {"k2", "v2"}, {"k3", "v1"}, {"k4", "v2"}};
+  auto expected =
+      SmallTagMap{{"k1", "v1"}, {"k2", "v2"}, {"k3", "v1"}, {"k4", "v2"}};
 
   map1.add_all(map2);
   EXPECT_EQ(map1, expected);
 }
 
 TEST(SmallTagMap, AddAllOverrides) {
-  auto map1 = SmallTagMap{{"k1", "v1"},{"k2","v2"}};
-  auto map2 = SmallTagMap{{"k3", "v3"},{"k1","v4"}};
-  auto expected = SmallTagMap{{"k1","v4"},{"k2", "v2"},{"k3", "v3"}};
+  auto map1 = SmallTagMap{{"k1", "v1"}, {"k2", "v2"}};
+  auto map2 = SmallTagMap{{"k3", "v3"}, {"k1", "v4"}};
+  auto expected = SmallTagMap{{"k1", "v4"}, {"k2", "v2"}, {"k3", "v3"}};
 
   map1.add_all(map2);
   EXPECT_EQ(map1, expected);

--- a/test/subscriptions_manager_test.cc
+++ b/test/subscriptions_manager_test.cc
@@ -9,8 +9,8 @@ Subscriptions* ParseSubscriptions(const std::string& subs_str);
 rapidjson::Document MeasurementsToJson(
     int64_t now_millis,
     const interpreter::TagsValuePairs::const_iterator& first,
-    const interpreter::TagsValuePairs::const_iterator& last,
-    bool validate, int64_t* added);
+    const interpreter::TagsValuePairs::const_iterator& last, bool validate,
+    int64_t* added);
 
 rapidjson::Document SubResultsToJson(
     int64_t now_millis, const SubscriptionResults::const_iterator& first,
@@ -51,10 +51,8 @@ static std::string json_to_str(const rapidjson::Document& json) {
 
 static void expect_eq_json(rapidjson::Document& expected,
                            rapidjson::Document& actual) {
-
-  EXPECT_EQ(expected, actual)
-            << "expected: " << json_to_str(expected)
-            << ", actual: " << json_to_str(actual);
+  EXPECT_EQ(expected, actual) << "expected: " << json_to_str(expected)
+                              << ", actual: " << json_to_str(actual);
 }
 
 TEST(SubscriptionManager, MeasurementsToJsonInvalid) {
@@ -71,7 +69,8 @@ TEST(SubscriptionManager, MeasurementsToJsonInvalid) {
   TagsValuePairs ms{std::move(m1), std::move(m2), std::move(m3)};
 
   int64_t added;
-  auto json = atlas::meter::MeasurementsToJson(1, ms.begin(), ms.end(), true, &added);
+  auto json =
+      atlas::meter::MeasurementsToJson(1, ms.begin(), ms.end(), true, &added);
   EXPECT_EQ(added, 0);
 }
 
@@ -89,7 +88,8 @@ TEST(SubscriptionManager, MeasurementsToJson) {
   TagsValuePairs ms{std::move(m1), std::move(m2), std::move(m3)};
 
   int64_t added;
-  auto json = atlas::meter::MeasurementsToJson(1, ms.begin(), ms.end(), true, &added);
+  auto json =
+      atlas::meter::MeasurementsToJson(1, ms.begin(), ms.end(), true, &added);
   EXPECT_EQ(added, 3);
 
   const char* expected =
@@ -124,4 +124,3 @@ TEST(SubscriptionManager, SubResToJson) {
   expected_json.Parse<kParseCommentsFlag | kParseNanAndInfFlag>(expected);
   expect_eq_json(expected_json, json);
 }
-

--- a/util/config_manager.h
+++ b/util/config_manager.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include "config.h"
 
 namespace atlas {
@@ -32,6 +34,8 @@ class ConfigManager {
 
  private:
   mutable std::mutex config_mutex;
+  std::mutex cv_mutex;
+  std::condition_variable cv;
   std::string local_file_name_;
   int refresh_ms_;
   std::shared_ptr<Config> current_config_;
@@ -42,6 +46,7 @@ class ConfigManager {
   void refresher() noexcept;
   void refresh_configs() noexcept;
   std::unique_ptr<Config> get_current_config() noexcept;
+  std::thread refresher_thread;
 };
 }  // namespace util
 }  // namespace atlas

--- a/util/http.cc
+++ b/util/http.cc
@@ -149,7 +149,7 @@ size_t header_callback(char* buffer, size_t size, size_t n_items,
 
 int http::conditional_get(const std::string& url, std::string& etag,
                           std::string* res) const {
-  auto logger = Logger();
+  const auto& logger = Logger();
   logger->debug("Conditionally getting url: {} etag: {}", url, etag);
   CurlHandle curl;
   // url to get
@@ -195,7 +195,7 @@ int http::conditional_get(const std::string& url, std::string& etag,
 }
 
 int http::get(const std::string& url, std::string* res) const {
-  auto logger = Logger();
+  const auto& logger = Logger();
   logger->debug("Getting url: {}", url);
   CurlHandle curl;
   // url to get
@@ -237,7 +237,7 @@ static int do_post(const std::string& url, int connect_timeout,
   curl.set_connect_timeout(connect_timeout);
   curl.set_read_timeout(read_timeout);
 
-  auto logger = Logger();
+  const auto& logger = Logger();
   logger->info("POSTing to url: {}", url);
   curl.set_url(url);
   curl.set_headers(std::move(headers));
@@ -391,7 +391,6 @@ static bool setup_handle_for_post(CurlHandle* handle, const std::string& url,
     return false;
   }
 
-  auto logger = Logger();
   handle->set_url(url);
   handle->set_headers(std::move(headers));
   handle->post_payload(std::move(compressed_payload), size);

--- a/util/logger.cc
+++ b/util/logger.cc
@@ -1,6 +1,4 @@
 #include "logger.h"
-#include "strings.h"
-#include <cstdlib>
 #include <iostream>
 
 namespace atlas {
@@ -8,11 +6,12 @@ namespace util {
 
 static constexpr const char* const kMainLogger = "atlas_main";
 
-static std::vector<std::string> logging_directories = {"/logs/atlasd",
-                                                       "./logs"};
+LogManager& log_manager() noexcept {
+  static auto* the_log_manager = new LogManager(kMainLogger);
+  return *the_log_manager;
+}
 
-static std::string current_logging_directory;
-static LogConfig current_log_config;
+LogManager::LogManager(std::string name) noexcept : name_{std::move(name)} {}
 
 static bool is_writable_dir(const std::string& dir) {
   struct stat dir_stat;
@@ -40,7 +39,7 @@ static bool writable_or_missing(const std::string& file) {
 }
 
 static constexpr const char* const kLogFileName = "atlasclient.log";
-static std::string get_logging_directory() {
+std::string LogManager::get_usable_logging_directory() const noexcept {
   for (const auto& log_dir : logging_directories) {
     if (is_writable_dir(log_dir) &&
         writable_or_missing(join_path(log_dir, kLogFileName))) {
@@ -50,51 +49,53 @@ static std::string get_logging_directory() {
   return "/tmp";
 }
 
-static void fallback_init_for_logger() noexcept {
-  auto logger = spdlog::get(kMainLogger);
-  if (logger) {
-    spdlog::drop(kMainLogger);
+void LogManager::fallback_init_for_logger() noexcept {
+  if (current_logger_) {
+    spdlog::drop(name_);
   }
 
-  spdlog::stderr_color_mt(kMainLogger);
+  current_logger_ = spdlog::stderr_color_mt(name_);
   current_logging_directory = "";
 }
 
-static void initialize_logger(const std::string& log_dir) {
+void LogManager::initialize_logger(const std::string& log_dir) noexcept {
   const auto& file_name = join_path(log_dir, kLogFileName);
   if (writable_or_missing(file_name)) {
     spdlog::set_error_handler([](const std::string& msg) {
       std::cerr << "Log error: " << msg << "\n";
     });
-    auto logger = spdlog::create<spdlog::sinks::rotating_file_sink_mt>(
+    current_logger_ = spdlog::create<spdlog::sinks::rotating_file_sink_mt>(
         kMainLogger, join_path(log_dir, "atlasclient"),
         SPDLOG_FILENAME_T("log"), current_log_config.max_size,
         current_log_config.max_files);
     current_logging_directory = log_dir;
-    logger->flush_on(spdlog::level::info);
+    current_logger_->flush_on(spdlog::level::info);
   } else {
     fallback_init_for_logger();
   }
 }
 
-static void initialize() {
+void LogManager::initialize() noexcept {
   try {
-    initialize_logger(get_logging_directory());
+    initialize_logger(get_usable_logging_directory());
   } catch (const spdlog::spdlog_ex& ex) {
     std::cerr << "Log initialization failed: " << ex.what() << "\n";
   }
 }
 
-static std::mutex logger_mutex;
-std::shared_ptr<spdlog::logger> Logger() noexcept {
+std::shared_ptr<spdlog::logger> LogManager::Logger() noexcept {
   std::lock_guard<std::mutex> lock(logger_mutex);
-  auto logger = spdlog::get(kMainLogger);
-  if (logger) {
-    return logger;
+  if (current_logger_) {
+    return current_logger_;
+  }
+
+  current_logger_ = spdlog::get(name_);
+  if (current_logger_) {
+    return current_logger_;
   }
 
   initialize();
-  return spdlog::get(kMainLogger);
+  return current_logger_;
 }
 
 static spdlog::level::level_enum level_from_int(int l) {
@@ -104,11 +105,10 @@ static spdlog::level::level_enum level_from_int(int l) {
   return static_cast<spdlog::level::level_enum>(l);
 }
 
-void SetLoggingDirs(const std::vector<std::string>& dirs) noexcept {
+void LogManager::SetLoggingDirs(const std::vector<std::string>& dirs) noexcept {
   std::lock_guard<std::mutex> lock(logger_mutex);
-  auto logger = spdlog::get(kMainLogger);
-  if (logger) {
-    spdlog::drop(kMainLogger);
+  if (current_logger_) {
+    spdlog::drop(name_);
     current_logging_directory = "";
   }
 
@@ -118,22 +118,22 @@ void SetLoggingDirs(const std::vector<std::string>& dirs) noexcept {
   initialize();
 }
 
-void UseConsoleLogger(int level) noexcept {
+void LogManager::UseConsoleLogger(int level) noexcept {
   std::lock_guard<std::mutex> lock(logger_mutex);
-  auto logger = spdlog::get(kMainLogger);
-  if (logger) {
-    spdlog::drop(kMainLogger);
+  if (current_logger_) {
+    spdlog::drop(name_);
   }
 
-  logger = spdlog::stdout_color_mt(kMainLogger);
-  logger->set_level(level_from_int(level));
+  current_logger_ = spdlog::stdout_color_mt(kMainLogger);
+  current_logger_->set_level(level_from_int(level));
   current_logging_directory = "";
 }
 
-void InitializeLogging(const LogConfig& config) noexcept {
-  std::lock_guard<std::mutex> lock(logger_mutex);
-
-  Logger()->set_level(level_from_int(config.verbosity));
+void LogManager::InitializeLogging(const LogConfig& config) noexcept {
+  // we can update the log level without dropping the logger
+  if (current_logger_) {
+    current_logger_->set_level(level_from_int(config.verbosity));
+  }
 
   auto new_size = config.max_size;
   auto new_files = config.max_files;
@@ -142,16 +142,20 @@ void InitializeLogging(const LogConfig& config) noexcept {
     return;
   }
 
+  // if we need to update the number or size of log files
+  // then we need to drop the logger and recreate it
   current_log_config = config;
-  auto logger = spdlog::get(kMainLogger);
-  if (logger) {
-    spdlog::drop(kMainLogger);
+  std::lock_guard<std::mutex> lock(logger_mutex);
+  if (current_logger_) {
+    spdlog::drop(name_);
   }
 
   initialize();
 }
 
-std::string GetLoggingDir() noexcept { return current_logging_directory; }
+std::string LogManager::GetLoggingDir() const noexcept {
+  return current_logging_directory;
+}
 
 }  // namespace util
 }  // namespace atlas

--- a/util/logger.h
+++ b/util/logger.h
@@ -7,11 +7,51 @@
 namespace atlas {
 namespace util {
 
-std::shared_ptr<spdlog::logger> Logger() noexcept;
-void UseConsoleLogger(int level) noexcept;
-void SetLoggingDirs(const std::vector<std::string>& dirs) noexcept;
-void InitializeLogging(const LogConfig& config) noexcept;
-std::string GetLoggingDir() noexcept;
+class LogManager {
+ public:
+  explicit LogManager(std::string name) noexcept;
+  std::shared_ptr<spdlog::logger> Logger() noexcept;
+  void UseConsoleLogger(int level) noexcept;
+  void SetLoggingDirs(const std::vector<std::string>& dirs) noexcept;
+  void InitializeLogging(const LogConfig& config) noexcept;
+  std::string GetLoggingDir() const noexcept;
+
+ private:
+  std::string name_;
+  std::mutex logger_mutex;
+  std::shared_ptr<spdlog::logger> current_logger_;
+  std::vector<std::string> logging_directories = {"/logs/atlasd", "./logs"};
+
+  std::string current_logging_directory;
+  LogConfig current_log_config;
+
+  std::string get_usable_logging_directory() const noexcept;
+  void fallback_init_for_logger() noexcept;
+  void initialize_logger(const std::string& log_dir) noexcept;
+  void initialize() noexcept;
+};
+
+LogManager& log_manager() noexcept;
+
+inline std::shared_ptr<spdlog::logger> Logger() noexcept {
+  return log_manager().Logger();
+}
+
+inline void UseConsoleLogger(int level) noexcept {
+  log_manager().UseConsoleLogger(level);
+}
+
+inline void SetLoggingDirs(const std::vector<std::string>& dirs) noexcept {
+  log_manager().SetLoggingDirs(dirs);
+}
+
+inline void InitializeLogging(const LogConfig& config) noexcept {
+  log_manager().InitializeLogging(config);
+}
+
+inline std::string GetLoggingDir() noexcept {
+  return log_manager().GetLoggingDir();
+}
 
 }  // namespace util
 }  // namespace atlas


### PR DESCRIPTION
* Make sure there are not static initialization issues around logging
* Fixed locking around `Logger` and setting new logging config.
* Avoid using `thread.detach`. This was causing some memory corruption
at shutdown time because the detached threads would attempt to read/write
member variables after the constructor for the object finished.
* Switch from `thread::sleep` to `cond_var.wait_for` which makes it
possible to `join` the threads without having to wait for the `sleep` to
finish.