### PR TITLE
Do not sleep before sending first batch of metrics

### DIFF
--- a/interpreter/interpreter.cc
+++ b/interpreter/interpreter.cc
@@ -11,30 +11,30 @@ namespace interpreter {
 inline void add_nonempty(const std::string::size_type i,
                          const std::string::size_type j, const std::string& s,
                          Expressions* result) {
-  // j starts pointing at the comma
-  std::string::size_type k = j - 1;
+  // j starts pointing at the comma or end of string
+  auto k = static_cast<int>(j) - 1;
   // trim right
-  while (static_cast<bool>(std::isspace(s[k]))) {
+  while (k >= 0 && static_cast<bool>(std::isspace(s[k]))) {
     --k;
   }
   // point to the last char that's not a space
   ++k;
 
   // only non-empty tokens
-  if (k > i) {
+  if (k > static_cast<int>(i)) {
     result->push_back(std::make_unique<Literal>(s.substr(i, k - i)));
   }
 }
 
-// split on ; and trim the elements. Does not add empty elements to the result
+// split on , and trim the elements. Does not add empty elements to the result
 void split(const std::string& s, Expressions* result) {
-  std::string::size_type i = 0;
+  auto i = std::string::size_type(0);
 
   // trim left
   while (static_cast<bool>(isspace(s[i]))) {
     ++i;
   }
-  std::string::size_type j = s.find(',', i);
+  auto j = s.find(',', i);
 
   while (j != std::string::npos) {
     add_nonempty(i, j, s, result);

--- a/meter/validation.cc
+++ b/meter/validation.cc
@@ -18,11 +18,11 @@ using util::intern_str;
 using util::StartsWith;
 using util::StrRef;
 
-static bool is_key_restricted(util::StrRef k) noexcept {
+static bool is_key_restricted(StrRef k) noexcept {
   return StartsWith(k, "nf.") || StartsWith(k, "atlas.");
 }
 
-static std::unordered_set<util::StrRef> kValidNfTags = {
+static std::unordered_set<StrRef> kValidNfTags = {
     intern_str("nf.node"),          intern_str("nf.cluster"),
     intern_str("nf.app"),           intern_str("nf.asg"),
     intern_str("nf.stack"),         intern_str("nf.ami"),
@@ -35,7 +35,7 @@ static auto kDsType = intern_str("atlas.dstype");
 static auto kLegacy = intern_str("atlas.legacy");
 static auto kNameRef = intern_str("name");
 
-static bool is_user_key_invalid(util::StrRef k) noexcept {
+static bool is_user_key_invalid(StrRef k) noexcept {
   if (StartsWith(k, "atlas.")) {
     return k != kDsType && k != kLegacy;
   }
@@ -47,7 +47,7 @@ static bool is_user_key_invalid(util::StrRef k) noexcept {
   return false;
 }
 
-bool empty_or_null(util::StrRef r) { return r.is_null() || r.length() == 0; }
+bool empty_or_null(StrRef r) { return r.is_null() || r.length() == 0; }
 
 bool IsValid(const Tags& tags) noexcept {
   std::string err_msg;


### PR DESCRIPTION
This fixes the case where the atlas client is initialized and stopped in
less time than it should take us to send the first batch of metrics.
Oridinarily we want to sleep a few seconds so we start collecting
metrics near the beginning of the step, but if we sleep then we cannot
notice the fact the user has requested a shutdown. Switch to the
condition variable that was introduced for this purpose.