### PR TITLE
Initialize config at startup

### DIFF
--- a/util/config.cc
+++ b/util/config.cc
@@ -86,8 +86,8 @@ std::ostream& operator<<(std::ostream& os, const HttpConfig& http_config) {
 std::ostream& operator<<(std::ostream& os, const LogConfig& log_config) {
   os << std::boolalpha;
   os << "L(V=" << log_config.verbosity << ",S=" << log_config.max_size
-     << ",N=" << log_config.max_files << ",DM=" << log_config.dump_metrics
-     << ",DS=" << log_config.dump_subscriptions << ")";
+     << ",N=" << log_config.max_files << ",DumpM=" << log_config.dump_metrics
+     << ",DumpS=" << log_config.dump_subscriptions << ")";
   os << std::noboolalpha;
 
   return os;

--- a/util/config_manager.cc
+++ b/util/config_manager.cc
@@ -74,6 +74,7 @@ void ConfigManager::refresher() noexcept {
 
 void ConfigManager::Start() noexcept {
   should_run_ = true;
+  refresh_configs();
   refresher_thread = std::thread(&ConfigManager::refresher, this);
 }
 


### PR DESCRIPTION
Previously the config was loaded asynchronously, now we force the config
to be loaded first before returning from the call to Start.

This prevents a race condition where other services could fetch config
values before the initial config is loaded, and therefore would get the
defaults.