### PR TITLE
Fix illegal memory access in InWord

### DIFF
--- a/interpreter/vocabulary.cc
+++ b/interpreter/vocabulary.cc
@@ -70,12 +70,13 @@ class LeWord : public Word {
 class InWord : public Word {
  public:
   OptionalString Execute(Context* context) override {
-    auto expr = context->PopExpression().get();
-    if (expr->GetType() != ExpressionType::List) {
+    auto list_expr = context->PopExpression();
+
+    if (list_expr->GetType() != ExpressionType::List) {
       return OptionalString(":in expects a list on the stack");
     }
 
-    auto list = static_cast<List*>(expr);
+    auto list = std::static_pointer_cast<List>(list_expr);
     auto key = context->PopString();
     auto in_expr = std::make_unique<InQuery>(key, list->ToStrings());
     context->Push(std::move(in_expr));

--- a/test/interpreter_test.cc
+++ b/test/interpreter_test.cc
@@ -235,3 +235,22 @@ TEST(Interpreter, GetQuery) {
   auto q = interpreter.GetQuery(":true,:all");
   EXPECT_TRUE(q->IsTrue());
 }
+
+TEST(Interpreter, InQuery) {
+  auto context = exec("name,(,sps,sps2,),:in");
+  ASSERT_EQ(1, context->StackSize());
+
+  auto expr = context->PopExpression();
+  ASSERT_TRUE(expression::IsQuery(*expr));
+
+  auto query = std::static_pointer_cast<Query>(expr);
+
+  Tags sps{{"name", "sps"}};
+  ASSERT_TRUE(query->Matches(sps));
+
+  Tags sps2{{"name", "sps2"}};
+  ASSERT_TRUE(query->Matches(sps2));
+
+  Tags sps3{{"name", "sps3"}};
+  ASSERT_FALSE(query->Matches(sps3));
+}


### PR DESCRIPTION
We need to get a copy of the shared pointer before calling `.get()`,
otherwise the memory will be freed before we access it