### PR TITLE
Synchronize http-test requests

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
   init_tags(&test_tags);
   std::string prefix{"atlas.client.test."};
   for (int minute = 0; minute < 5; ++minute) {
-    logger->info("Starting to generate 50k metrics");
+    logger->info("Starting to generate metrics");
     for (int i = 0; i < 5; ++i) {
       counter(prefix + std::to_string(i), test_tags)->Increment();
     }

--- a/meter/subscription_registry.cc
+++ b/meter/subscription_registry.cc
@@ -69,7 +69,6 @@ class SubscriptionRegistry::impl {
 
  private:
   std::unique_ptr<interpreter::Interpreter> interpreter_;
-  // TODO(dmuino) use a concurrent map
   mutable std::mutex meters_mutex;
   std::unordered_map<IdPtr, std::shared_ptr<Meter>> meters_;
 };


### PR DESCRIPTION
This should fix the flaky http tests. Since the requests vector is
modified by a different thread there is no visibility guarantee for the
tests to get the latest requests unless some synchronization primitives
enforce that. This PR introduces a mutex to achieve that.