### PR TITLE
Dynamically grow buffer decompressing GET payload

### DIFF
--- a/util/buffer.cc
+++ b/util/buffer.cc
@@ -1,0 +1,45 @@
+#include "buffer.h"
+#include "logger.h"
+#include "gzip.h"
+
+namespace atlas {
+namespace util {
+
+void Buffer::append(void* data, size_t data_size) {
+  memory = static_cast<char*>(realloc(memory, size + data_size + 1));
+  if (memory == nullptr) {
+    throw std::bad_alloc();
+  }
+
+  memcpy(memory + size, data, data_size);
+  size += data_size;
+  memory[size] = 0;
+}
+
+void Buffer::assign(std::string* s) { s->assign(memory, size); }
+
+void Buffer::uncompress_to(std::string* s) {
+  auto res = inflate_string(s, memory, size);
+  if (res != Z_OK) {
+    std::string err_msg;
+    switch (res) {
+      case Z_MEM_ERROR:
+        err_msg = "Out of memory";
+        break;
+      case Z_DATA_ERROR:
+        err_msg = "Invalid or incomplete compressed data";
+        break;
+      case Z_STREAM_ERROR:
+        err_msg = "Invalid compression level";
+        break;
+      default:
+        err_msg = std::to_string(res);
+    }
+    Logger()->error("Unable to decompress payload (compressed size={}) err={}",
+                    size, err_msg);
+  }
+  return;
+}
+
+}  // namespace util
+}  // namespace atlas

--- a/util/buffer.h
+++ b/util/buffer.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+namespace atlas {
+namespace util {
+
+class Buffer {
+ public:
+  Buffer() : memory(static_cast<char*>(malloc(1))) {}
+  ~Buffer() { free(memory); }
+  Buffer(const Buffer&) = delete;
+  Buffer& operator=(const Buffer&) = delete;
+  Buffer& operator=(Buffer&&) = delete;
+  Buffer(Buffer&&) = delete;
+  void append(void* data, size_t data_size);
+  void assign(std::string* s);
+  void uncompress_to(std::string* s);
+
+ private:
+  char* memory;
+  size_t size = 0;
+};
+
+}  // namespace util
+}  // namespace atlas

--- a/util/gzip.cc
+++ b/util/gzip.cc
@@ -1,5 +1,8 @@
 #include "gzip.h"
 
+#include "buffer.h"
+#include <string>
+
 #ifndef z_const
 #define z_const
 #endif
@@ -40,6 +43,55 @@ int gzip_compress(char* dest, size_t* destLen, const char* source,
   return deflateEnd(&stream);
 }
 
+class inflate_guard {
+  z_stream* stream_;
+  int init;
+
+ public:
+  explicit inflate_guard(z_stream* stream) : stream_(stream) {
+    init = inflateInit2(stream_, kWindowBits);
+  }
+  ~inflate_guard() {
+    if (init == Z_OK) {
+      inflateEnd(stream_);
+    }
+  }
+  int init_result() const { return init; }
+};
+
+int inflate_string(std::string* dest, const char* source, size_t sourceLen) {
+  Buffer out;
+  char inflate_buf[65536];
+  z_stream stream;
+
+  stream.next_in = reinterpret_cast<z_const Bytef*>(const_cast<char*>(source));
+  stream.avail_in = static_cast<uInt>(sourceLen);
+  stream.next_out = nullptr;
+  stream.avail_out = 0;
+  stream.zalloc = static_cast<alloc_func>(nullptr);
+  stream.zfree = static_cast<free_func>(nullptr);
+  inflate_guard guard(&stream);
+  if (guard.init_result() != Z_OK) {
+    return guard.init_result();
+  }
+
+  while (stream.avail_in > 0) {
+    stream.avail_out = sizeof inflate_buf;
+    stream.next_out = reinterpret_cast<Bytef*>(inflate_buf);
+    auto ret = inflate(&stream, Z_NO_FLUSH);
+    if (ret == Z_NEED_DICT) {
+      ret = Z_DATA_ERROR;
+    }
+    if (ret == Z_DATA_ERROR || ret == Z_MEM_ERROR) {
+      return ret;
+    }
+    auto inflated = sizeof inflate_buf - stream.avail_out;
+    out.append(inflate_buf, inflated);
+  }
+  out.assign(dest);
+  return Z_OK;
+}
+
 int gzip_uncompress(char* dest, size_t* destLen, const char* source,
                     size_t sourceLen) {
   // no initialization due to gcc 4.8 bug
@@ -51,14 +103,14 @@ int gzip_uncompress(char* dest, size_t* destLen, const char* source,
   stream.zalloc = static_cast<alloc_func>(nullptr);
   stream.zfree = static_cast<free_func>(nullptr);
 
-  auto err = inflateInit2(&stream, kWindowBits);
+  inflate_guard guard(&stream);
+  auto err = guard.init_result();
   if (err != Z_OK) {
     return err;
   }
 
   err = inflate(&stream, Z_FINISH);
   if (err != Z_STREAM_END) {
-    inflateEnd(&stream);
     if (err == Z_NEED_DICT || (err == Z_BUF_ERROR && stream.avail_in == 0)) {
       return Z_DATA_ERROR;
     }
@@ -66,7 +118,8 @@ int gzip_uncompress(char* dest, size_t* destLen, const char* source,
   }
   *destLen = stream.total_out;
 
-  return inflateEnd(&stream);
+  return Z_OK;
 }
+
 }  // namespace util
 }  // namespace atlas

--- a/util/gzip.h
+++ b/util/gzip.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <zlib.h>
 
 namespace atlas {
@@ -11,5 +12,8 @@ int gzip_compress(char* dest, size_t* destLen, const char* source,
                   size_t sourceLen);
 int gzip_uncompress(char* dest, size_t* destLen, const char* source,
                     size_t sourceLen);
+
+int inflate_string(std::string* dest, const char* source, size_t sourceLen);
+
 }  // namespace util
 }  // namespace atlas


### PR DESCRIPTION
This removes the 10MB hardcoded limit we had for handling GET requests
with content encoded by gzip. Fixes #2