### PR TITLE
Use a vector as our buffer implementation

### DIFF
--- a/util/buffer.cc
+++ b/util/buffer.cc
@@ -6,20 +6,14 @@ namespace atlas {
 namespace util {
 
 void Buffer::append(void* data, size_t data_size) {
-  memory = static_cast<char*>(realloc(memory, size + data_size + 1));
-  if (memory == nullptr) {
-    throw std::bad_alloc();
-  }
-
-  memcpy(memory + size, data, data_size);
-  size += data_size;
-  memory[size] = 0;
+  auto* p = static_cast<char*>(data);
+  buf.insert(buf.end(), p, p + data_size);
 }
 
-void Buffer::assign(std::string* s) { s->assign(memory, size); }
+void Buffer::assign(std::string* s) { s->assign(buf.begin(), buf.end()); }
 
 void Buffer::uncompress_to(std::string* s) {
-  auto res = inflate_string(s, memory, size);
+  auto res = inflate_string(s, buf.data(), buf.size());
   if (res != Z_OK) {
     std::string err_msg;
     switch (res) {
@@ -36,9 +30,8 @@ void Buffer::uncompress_to(std::string* s) {
         err_msg = std::to_string(res);
     }
     Logger()->error("Unable to decompress payload (compressed size={}) err={}",
-                    size, err_msg);
+                    buf.size(), err_msg);
   }
-  return;
 }
 
 }  // namespace util

--- a/util/buffer.h
+++ b/util/buffer.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <string>
+#include <vector>
 namespace atlas {
 namespace util {
 
 class Buffer {
  public:
-  Buffer() : memory(static_cast<char*>(malloc(1))) {}
-  ~Buffer() { free(memory); }
+  Buffer() = default;
   Buffer(const Buffer&) = delete;
   Buffer& operator=(const Buffer&) = delete;
   Buffer& operator=(Buffer&&) = delete;
@@ -17,8 +17,7 @@ class Buffer {
   void uncompress_to(std::string* s);
 
  private:
-  char* memory;
-  size_t size = 0;
+  std::vector<char> buf;
 };
 
 }  // namespace util


### PR DESCRIPTION
The previous buffer code was meant only to be used with curl/gzip which
pass big blocks of memory and therefore keeping the number of
reallocations/copies small. It relied on this fact to reduce to a
minimum the memory footprint (capacity=size).

Since buffer is now a more publicly visible class, then it makes sense
to use a more general purpose data structure.