### PR TITLE
Remove dependency on fmt/ from public api

### DIFF
--- a/interpreter/tags_value.cc
+++ b/interpreter/tags_value.cc
@@ -1,4 +1,5 @@
 #include "tags_value.h"
+#include "../meter/id_format.h"
 
 namespace atlas {
 namespace interpreter {
@@ -6,25 +7,37 @@ namespace interpreter {
 const OptionalString kNone{nullptr};
 const util::StrRef kNameRef = util::intern_str("name");
 
+void IdTagsValuePair::dump(std::ostream& os) const noexcept {
+  os << "IdTagsValuePair(id=" << *id_ << ",common_tags=" << *common_tags_
+     << ",value=" << value_ << ")";
+}
+
+void SimpleTagsValuePair::dump(std::ostream& os) const noexcept {
+  os << "SimpleTagsValuePair(tags=" << tags_ << ",value=" << value_ << ")";
+}
+
 std::ostream& operator<<(std::ostream& os, const TagsValuePair& tagsValuePair) {
   tagsValuePair.dump(os);
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const std::shared_ptr<TagsValuePair>& tagsValuePair) {
+std::ostream& operator<<(std::ostream& os,
+                         const std::shared_ptr<TagsValuePair>& tagsValuePair) {
   tagsValuePair->dump(os);
   return os;
 }
 
-std::unique_ptr<TagsValuePair> TagsValuePair::from(const meter::Measurement& measurement, const meter::Tags* common_tags) noexcept {
-  return std::make_unique<IdTagsValuePair>(measurement.id, common_tags, measurement.value);
+std::unique_ptr<TagsValuePair> TagsValuePair::from(
+    const meter::Measurement& measurement,
+    const meter::Tags* common_tags) noexcept {
+  return std::make_unique<IdTagsValuePair>(measurement.id, common_tags,
+                                           measurement.value);
 }
 
-std::unique_ptr<TagsValuePair> TagsValuePair::of(meter::Tags&& tags, double value) noexcept {
+std::unique_ptr<TagsValuePair> TagsValuePair::of(meter::Tags&& tags,
+                                                 double value) noexcept {
   return std::make_unique<SimpleTagsValuePair>(std::move(tags), value);
 }
 
 }  // namespace interpreter
 }  // namespace atlas
-
-

--- a/interpreter/tags_value.h
+++ b/interpreter/tags_value.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../meter/id_format.h"
 #include "../meter/measurement.h"
 #include "../util/optional.h"
 #include <cstdlib>
@@ -43,9 +42,7 @@ class SimpleTagsValuePair : public TagsValuePair {
 
   meter::Tags all_tags() const noexcept override { return tags_; }
 
-  void dump(std::ostream& os) const noexcept override {
-    os << "SimpleTagsValuePair(tags=" << tags_ << ",value=" << value_ << ")";
-  }
+  void dump(std::ostream& os) const noexcept override;
 
   double value() const noexcept override { return value_; }
 
@@ -86,10 +83,7 @@ class IdTagsValuePair : public TagsValuePair {
     return tags;
   }
 
-  void dump(std::ostream& os) const noexcept override {
-    os << "IdTagsValuePair(id=" << *id_ << ",common_tags=" << *common_tags_
-       << ",value=" << value_ << ")";
-  }
+  void dump(std::ostream& os) const noexcept override;
 
  private:
   meter::IdPtr id_;


### PR DESCRIPTION
Since it's a header only library it causes problems for users of this
library. Remove it from that tags_value.h header that gets used as part
of our public API