### PR TITLE
Track the number of measurements pre/post rollups

### DIFF
--- a/meter/atlas_registry.cc
+++ b/meter/atlas_registry.cc
@@ -119,21 +119,12 @@ void AtlasRegistry::RegisterMonitor(std::shared_ptr<Meter> meter) noexcept {
   InsertIfNeeded(meter);
 }
 
-/*
-  raw_measurements_size->Update(all.size());
-  main_measurements_size->Update(result->size());
- */
-
-/*
-
- */
-
 AtlasRegistry::AtlasRegistry(int64_t freq_millis, const Clock* clock) noexcept
     : impl_{std::make_unique<impl>()},
       clock_{clock},
       freq_millis_{freq_millis},
       freq_tags{} {
-  auto freq_value = fmt::format("{:02d}s", freq_millis / 1000);
+  auto freq_value = util::secs_for_millis(freq_millis);
   freq_tags.add("id", freq_value.c_str());
   meters_size = gauge(CreateId("atlas.numMeters", freq_tags));
 }

--- a/meter/subscription_manager.cc
+++ b/meter/subscription_manager.cc
@@ -331,12 +331,16 @@ SubscriptionResults SubscriptionManager::get_lwc_metrics(
 // the whole send process (get measurements, get tagsvaluepairs, eval, send)
 TagsValuePairs get_main_measurements(const util::Config& cfg,
                                      const Tags* common_tags,
-                                     const Registry* registry,
+                                     Registry* registry,
                                      const Evaluator& evaluator) {
   using interpreter::Query;
   using interpreter::TagsValuePair;
 
   const auto all_measurements = registry->measurements();
+  const auto freq_value = util::secs_for_millis(kMainFrequencyMillis);
+  Tags freq_tags{{"id", freq_value.c_str()}};
+  registry->gauge("atlas.client.rawMeasurements", freq_tags)
+      ->Update(all_measurements.size());
   auto result = TagsValuePairs();
   auto logger = Logger();
 
@@ -388,6 +392,9 @@ TagsValuePairs get_main_measurements(const util::Config& cfg,
     std::move(rule_result.begin(), rule_result.end(),
               std::back_inserter(result));
   }
+
+  registry->gauge("atlas.client.mainMeasurements", freq_tags)
+      ->Update(result.size());
   return result;
 }
 


### PR DESCRIPTION
Add a couple of gauges so we can track the number of measurements
produced by the registered meters, plus the number reported after
applying the rollup policy