### PR TITLE
Remove expired meters from registry

### DIFF
--- a/meter/atlas_registry.h
+++ b/meter/atlas_registry.h
@@ -47,15 +47,19 @@ class AtlasRegistry : public Registry {
 
   Meters meters() const noexcept override;
 
-  Measurements measurements() const noexcept override;
+  Measurements measurements() noexcept override;
 
   std::shared_ptr<Gauge<double>> max_gauge(IdPtr id) noexcept override;
+
+ protected:
+  void expire_meters() noexcept;
 
  private:
   const Clock* clock_;
   int64_t freq_millis_;
   Tags freq_tags;
   mutable std::shared_ptr<Gauge<double>> meters_size;
+  mutable std::shared_ptr<Counter> expired_meters;
 
   std::shared_ptr<Meter> InsertIfNeeded(std::shared_ptr<Meter> meter) noexcept;
   std::shared_ptr<Meter> GetMeter(IdPtr id) noexcept;

--- a/meter/registry.h
+++ b/meter/registry.h
@@ -44,7 +44,7 @@ class Registry {
 
   virtual Meters meters() const noexcept = 0;
 
-  virtual Measurements measurements() const noexcept = 0;
+  virtual Measurements measurements() noexcept = 0;
 
   std::shared_ptr<Counter> counter(std::string name,
                                    const Tags& tags = kEmptyTags) {

--- a/test/atlas_registry_test.cc
+++ b/test/atlas_registry_test.cc
@@ -18,70 +18,31 @@ using atlas::interpreter::TagsValuePair;
 using atlas::interpreter::TagsValuePairs;
 using namespace atlas::meter;
 
-TEST(SubscriptionRegistry, Eval) {
-  TestRegistry registry;
-  const auto& manual_clock = static_cast<const ManualClock&>(registry.clock());
-  manual_clock.SetWall(42);
-
-  const std::string s{":true,:all"};
-
-  Tags tags1{{"name", "m1"}, {"k1", "v1"}, {"k1", "v2"}};
-  Tags tags2{{"name", "m2"}, {"k1", "v1"}, {"k1", "v2"}};
-  Tags tags3{{"name", "m3"}, {"k1", "v1"}, {"k1", "v2"}};
-  auto m1 = TagsValuePair::of(std::move(tags1), 1.0);
-  auto m2 = TagsValuePair::of(std::move(tags2), 2.0);
-  auto m3 = TagsValuePair::of(std::move(tags3), 3.0);
-  auto measurements = std::make_shared<TagsValuePairs>();
-  measurements->push_back(std::move(m1));
-  measurements->push_back(std::move(m2));
-  measurements->push_back(std::move(m3));
-  //  const auto& res = registry.eval(s, measurements);
-  //  EXPECT_EQ(res->size(), 3);
-}
-
-TEST(SubscriptionRegistry, MainMetrics) {
-  TestRegistry registry;
-  const auto& manual_clock = static_cast<const ManualClock&>(registry.clock());
-  manual_clock.SetWall(42);
+TEST(AtlasRegistry, Meters) {
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  r.SetWall(42);
   Tags tags{{"k1", "v1"}, {"k2", "v2"}};
-  auto id1 = registry.CreateId("m1", tags);
-  auto id3 = registry.CreateId("m3", tags);
+  auto id1 = r.CreateId("m1", tags);
+  auto id3 = r.CreateId("m3", tags);
   Tags tags_for_4{{"k1", "v1"}, {"k2", "v3"}};
-  auto id4 = registry.CreateId("m3", tags_for_4);
+  auto id4 = r.CreateId("m3", tags_for_4);
 
-  registry.counter(id1)->Increment();
+  auto ctr = r.counter(id1);
+  ctr->Increment();
   // make sure we re-use ids
-  registry.counter(registry.CreateId("m2", tags))->Add(60);
-  registry.counter(registry.CreateId("m2", tags))->Add(60);
-  registry.counter(id3)->Add(60);
-  registry.counter(id4)->Add(60);
+  r.counter(r.CreateId("m2", tags))->Add(60);
+  r.counter(r.CreateId("m2", tags))->Add(60);
+  r.counter(id3)->Add(60);
+  r.counter(id4)->Add(60);
 
-  auto pub_config = std::vector<std::string>{
-      "name,m1,:eq,:all", ":true,(,k2,nf.node,nf.region,),:drop-tags"};
-  auto cfg = Config().WithPublishConfig(pub_config);
-  manual_clock.SetWall(60042);
-  auto common_tags = cfg.CommonTags();
-  const auto& res = registry.measurements();
-  //  EXPECT_EQ(res.size(), 3);
-
-  auto name_num_tags = std::unordered_map<std::string, size_t>(res.size());
-  auto name_value = std::unordered_map<std::string, double>(res.size());
-
-  /*
-  for (const auto& m : res) {
-    const auto& t = m->all_tags();
-    const auto& name = t.at(kNameRef).get();
-    name_num_tags[name] = t.size();
-    name_value[name] = m->value();
+  {
+    auto ms = r.my_meters();
+    EXPECT_EQ(ms.size(), 4);
   }
 
-  auto ct = common_tags.size();
-  auto expected_name_num_tags = std::unordered_map<std::string, size_t>(
-      {{"m1", 4u + ct}, {"m2", 3u + ct - 2}, {"m3", 3u + ct - 2}});
-  EXPECT_EQ(name_num_tags, expected_name_num_tags);
-
-  auto expected_name_value = std::unordered_map<std::string, double>(
-      {{"m1", 1 / 60.0}, {"m2", 120 / 60.0}, {"m3", 120 / 60.0}});
-  EXPECT_EQ(name_value, expected_name_value);
-   */
+  r.SetWall(atlas::meter::MAX_IDLE_TIME + 43);
+  r.expire();
+  auto ms = r.my_meters();
+  EXPECT_EQ(ms.size(), 1);
 }

--- a/test/bucket_counter_test.cc
+++ b/test/bucket_counter_test.cc
@@ -6,6 +6,7 @@
 
 using atlas::meter::BucketCounter;
 using atlas::meter::kEmptyTags;
+using atlas::meter::ManualClock;
 using atlas::meter::Measurement;
 using atlas::meter::Measurements;
 using atlas::meter::Registry;
@@ -15,7 +16,8 @@ using atlas::util::Logger;
 using std::chrono::microseconds;
 
 TEST(BucketCounter, Init) {
-  TestRegistry r;
+  ManualClock m;
+  TestRegistry r{&m};
   auto id = r.CreateId("test", kEmptyTags);
   BucketCounter b(&r, id, Age(microseconds{100}));
   auto ms = r.measurements_for_name("test");
@@ -25,7 +27,8 @@ TEST(BucketCounter, Init) {
 // micros to nanos
 static constexpr int64_t kMicrosToNanos = 1000l;
 TEST(BucketCounter, Record) {
-  TestRegistry r;
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
   r.SetWall(1000);
 
   auto id = r.CreateId("test", kEmptyTags);

--- a/test/bucket_dist_summary_test.cc
+++ b/test/bucket_dist_summary_test.cc
@@ -6,6 +6,7 @@
 
 using atlas::meter::BucketDistributionSummary;
 using atlas::meter::kEmptyTags;
+using atlas::meter::ManualClock;
 using atlas::meter::Measurement;
 using atlas::meter::Tag;
 using atlas::meter::bucket_functions::Age;
@@ -13,7 +14,8 @@ using atlas::util::Logger;
 using std::chrono::seconds;
 
 TEST(BucketDistributionSummary, Init) {
-  TestRegistry r;
+  ManualClock m;
+  TestRegistry r{&m};
 
   auto id = r.CreateId("test", kEmptyTags);
   BucketDistributionSummary ds(&r, id, Age(seconds{60}));
@@ -25,7 +27,8 @@ TEST(BucketDistributionSummary, Init) {
 static constexpr int64_t kSecsToNanos = 1000l * 1000l * 1000l;
 
 TEST(BucketDistributionSummary, Record) {
-  TestRegistry r;
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
   r.SetWall(1000);
 
   auto id = r.CreateId("test", kEmptyTags);

--- a/test/bucket_timer_test.cc
+++ b/test/bucket_timer_test.cc
@@ -6,6 +6,7 @@
 
 using atlas::meter::BucketTimer;
 using atlas::meter::kEmptyTags;
+using atlas::meter::ManualClock;
 using atlas::meter::Measurement;
 using atlas::meter::Tag;
 using atlas::meter::bucket_functions::Age;
@@ -15,7 +16,8 @@ using std::chrono::milliseconds;
 using std::chrono::seconds;
 
 TEST(BucketTimer, Init) {
-  TestRegistry r;
+  ManualClock m;
+  TestRegistry r{&m};
 
   auto id = r.CreateId("test", kEmptyTags);
   BucketTimer t(&r, id, Age(milliseconds{100}));
@@ -26,7 +28,8 @@ TEST(BucketTimer, Init) {
 static constexpr auto kMillisToSecs = 1 / 1000.0;
 
 TEST(BucketTimer, Record) {
-  TestRegistry r;
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
   r.SetWall(1000);
 
   auto id = r.CreateId("test", kEmptyTags);
@@ -62,7 +65,8 @@ TEST(BucketTimer, Record) {
 }
 
 TEST(BucketTimer, Latency) {
-  TestRegistry r;
+  ManualClock m;
+  TestRegistry r{&m};
   r.SetWall(1000);
 
   auto id = r.CreateId("bucket.t", kEmptyTags);

--- a/test/default_dist_summary_test.cc
+++ b/test/default_dist_summary_test.cc
@@ -8,8 +8,7 @@ using namespace atlas::meter;
 using atlas::util::kMainFrequencyMillis;
 
 static ManualClock manual_clock;
-
-static TestRegistry test_registry;
+static TestRegistry test_registry{&manual_clock};
 static auto id = test_registry.CreateId("foo", kEmptyTags);
 
 static std::unique_ptr<DefaultDistributionSummary> newDistSummary() {

--- a/test/default_max_gauge_test.cc
+++ b/test/default_max_gauge_test.cc
@@ -9,19 +9,18 @@ using atlas::util::kMainFrequencyMillis;
 
 static ManualClock manual_clock;
 
-static TestRegistry test_registry;
-static auto id = test_registry.CreateId("foo", kEmptyTags);
-
 static std::unique_ptr<DefaultMaxGaugeInt> newMaxGaugeInt() {
   manual_clock.SetWall(0);
-  return std::make_unique<DefaultMaxGaugeInt>(id, manual_clock,
-                                              kMainFrequencyMillis);
+  return std::make_unique<DefaultMaxGaugeInt>(
+      std::make_shared<Id>("foo", kEmptyTags), manual_clock,
+      kMainFrequencyMillis);
 }
 
 static std::unique_ptr<DefaultMaxGauge<double>> newMaxGaugeDouble() {
   manual_clock.SetWall(0);
-  return std::make_unique<DefaultMaxGauge<double>>(id, manual_clock,
-                                                   kMainFrequencyMillis);
+  return std::make_unique<DefaultMaxGauge<double>>(
+      std::make_shared<Id>("foo", kEmptyTags), manual_clock,
+      kMainFrequencyMillis);
 }
 
 TEST(DefaultMaxGaugeInt, Init) {

--- a/test/function_gauge_test.cc
+++ b/test/function_gauge_test.cc
@@ -12,8 +12,6 @@ using atlas::meter::Meter;
 
 static ManualClock manual_clock;
 static constexpr auto kNAN = std::numeric_limits<double>::quiet_NaN();
-static TestRegistry testRegistry;
-static auto id = testRegistry.CreateId("foo", kEmptyTags);
 
 void expect_gauge_value(const Meter& m, double expected) {
   auto measures = m.Measure();
@@ -27,6 +25,7 @@ void expect_gauge_value(const Meter& m, double expected) {
 }
 
 TEST(FunctionGauge, Init) {
+  auto id = std::make_shared<Id>("foo", kEmptyTags);
   auto n = std::make_shared<int64_t>(0);
   auto f = [](int64_t v) { return v * 2.0; };
   FunctionGauge<int64_t> fg{id, manual_clock, n, f};
@@ -36,6 +35,7 @@ TEST(FunctionGauge, Init) {
 }
 
 TEST(FunctionGauge, Value) {
+  auto id = std::make_shared<Id>("foo", kEmptyTags);
   auto n = std::make_shared<int64_t>(21);
   auto f = [](int64_t v) { return v * 2.0; };
   FunctionGauge<int64_t> fg{id, manual_clock, n, f};
@@ -45,6 +45,7 @@ TEST(FunctionGauge, Value) {
 }
 
 TEST(FunctionGauge, Expiration) {
+  auto id = std::make_shared<Id>("foo", kEmptyTags);
   auto n = std::make_shared<int64_t>(21);
   auto f = [](int64_t v) { return v * 2.0; };
   FunctionGauge<int64_t> fg{id, manual_clock, n, f};

--- a/test/http_test.cc
+++ b/test/http_test.cc
@@ -18,6 +18,7 @@
 #include <thread>
 #include <fstream>
 
+using atlas::meter::ManualClock;
 using atlas::meter::Tags;
 using atlas::util::gzip_uncompress;
 using atlas::util::http;
@@ -52,7 +53,8 @@ TEST(HttpTest, Post) {
   logger->info("Server started on port {}", port);
 
   auto cfg = HttpConfig();
-  auto registry = std::make_shared<TestRegistry>();
+  ManualClock clock;
+  auto registry = std::make_shared<TestRegistry>(&clock);
   http client{registry, cfg};
   auto url = fmt::format("http://localhost:{}/foo", port);
   const std::string post_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -128,7 +130,8 @@ TEST(HttpTest, PostBatches) {
   logger->info("Server started on port {}", port);
 
   auto cfg = HttpConfig();
-  auto registry = std::make_shared<TestRegistry>();
+  ManualClock clock;
+  auto registry = std::make_shared<TestRegistry>(&clock);
   http client{registry, cfg};
 
   auto url = fmt::format("http://localhost:{}/foo", port);
@@ -181,7 +184,8 @@ TEST(HttpTest, Timeout) {
   auto cfg = HttpConfig();
   cfg.connect_timeout = 1;
   cfg.read_timeout = 1;
-  auto registry = std::make_shared<TestRegistry>();
+  ManualClock clock;
+  auto registry = std::make_shared<TestRegistry>(&clock);
   http client{registry, cfg};
   auto url = fmt::format("http://localhost:{}/foo", port);
   const std::string post_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -212,7 +216,8 @@ TEST(HttpTest, ConditionalGet) {
 
   auto cfg = HttpConfig();
   cfg.read_timeout = 60;
-  auto registry = std::make_shared<TestRegistry>();
+  ManualClock clock;
+  auto registry = std::make_shared<TestRegistry>(&clock);
   http client{registry, cfg};
   auto url = fmt::format("http://localhost:{}/get", port);
 
@@ -281,7 +286,8 @@ TEST(HttpTest, CompressedGet) {
 
   auto cfg = HttpConfig();
   cfg.read_timeout = 60;
-  auto registry = std::make_shared<TestRegistry>();
+  ManualClock manual_clock;
+  auto registry = std::make_shared<TestRegistry>(&manual_clock);
   http client{registry, cfg};
 
   auto url = fmt::format("http://localhost:{}/compressed", port);

--- a/test/interval_counter_test.cc
+++ b/test/interval_counter_test.cc
@@ -7,11 +7,13 @@
 using atlas::meter::Id;
 using atlas::meter::IntervalCounter;
 using atlas::meter::kEmptyTags;
+using atlas::meter::ManualClock;
 using atlas::meter::Measurements;
 using atlas::util::intern_str;
 
 TEST(IntervalCounter, Init) {
-  TestRegistry r;
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
   r.SetWall(42 * 1000);
   auto id = r.CreateId("test", kEmptyTags);
   IntervalCounter c{&r, id};
@@ -21,7 +23,8 @@ TEST(IntervalCounter, Init) {
 }
 
 TEST(IntervalCounter, Interval) {
-  TestRegistry r;
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
   r.SetWall(0);
   auto id = r.CreateId("test", kEmptyTags);
   IntervalCounter c{&r, id};
@@ -37,7 +40,8 @@ TEST(IntervalCounter, Interval) {
 }
 
 TEST(IntervalCounter, Increment) {
-  TestRegistry r;
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
   auto id = r.CreateId("test", kEmptyTags);
   IntervalCounter c{&r, id};
 
@@ -65,7 +69,8 @@ void assert_interval_counter(const Measurements& ms, int64_t timestamp,
 }
 
 TEST(IntervalCounter, Measure) {
-  TestRegistry r;
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
   auto id = r.CreateId("test", kEmptyTags);
   IntervalCounter c{&r, id};
 
@@ -85,7 +90,8 @@ TEST(IntervalCounter, Measure) {
 }
 
 TEST(IntervalCounter, ReusesInstance) {
-  TestRegistry r;
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
 
   auto id = r.CreateId("test", kEmptyTags);
 
@@ -102,7 +108,8 @@ TEST(IntervalCounter, ReusesInstance) {
 
 TEST(IntervalCounter, Expiration) {
   // make sure we always report the interval since last update
-  TestRegistry r;
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
 
   auto id = r.CreateId("test", kEmptyTags);
   IntervalCounter c{&r, id};

--- a/test/monotonic_counter_test.cc
+++ b/test/monotonic_counter_test.cc
@@ -5,14 +5,16 @@
 using namespace atlas::meter;
 
 TEST(MonotonicCounter, Init) {
-  TestRegistry registry;
-  MonotonicCounter counter{&registry, registry.CreateId("ctr", kEmptyTags)};
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  MonotonicCounter counter{&r, r.CreateId("ctr", kEmptyTags)};
   EXPECT_EQ(0, counter.Count()) << "A new counter should report a value of 0";
 }
 
 TEST(MonotonicCounter, Set) {
-  TestRegistry registry;
-  MonotonicCounter counter{&registry, registry.CreateId("ctr", kEmptyTags)};
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  MonotonicCounter counter{&r, r.CreateId("ctr", kEmptyTags)};
   counter.Set(100);
 
   EXPECT_EQ(100, counter.Count()) << "Should honor Set";
@@ -22,85 +24,89 @@ TEST(MonotonicCounter, Set) {
 }
 
 TEST(MonotonicCounter, NotEnoughData) {
-  TestRegistry registry;
-  MonotonicCounter counter{&registry, registry.CreateId("ctr", kEmptyTags)};
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  MonotonicCounter counter{&r, r.CreateId("ctr", kEmptyTags)};
 
-  EXPECT_EQ(0, registry.measurements_for_name("ctr").size())
+  EXPECT_EQ(0, r.measurements_for_name("ctr").size())
       << "Not enough data for a rate";
 
-  registry.SetWall(61000);
+  r.SetWall(61000);
   counter.Set(100);
-  EXPECT_EQ(0, registry.measurements_for_name("ctr").size())
+  EXPECT_EQ(0, r.measurements_for_name("ctr").size())
       << "Not enough data for a rate";
 
-  registry.SetWall(121000);
+  r.SetWall(121000);
   counter.Set(200);
-  registry.SetWall(181000);
-  auto ms = registry.measurements_for_name("ctr");
+  r.SetWall(181000);
+  auto ms = r.measurements_for_name("ctr");
   EXPECT_EQ(1, ms.size()) << "Finally enough data";
 
   EXPECT_DOUBLE_EQ(100 / 60.0, ms.at(0).value) << "Computes the correct rate";
 }
 
 TEST(MonotonicCounter, Rate) {
-  TestRegistry registry;
-  MonotonicCounter counter{&registry, registry.CreateId("ctr", kEmptyTags)};
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  MonotonicCounter counter{&r, r.CreateId("ctr", kEmptyTags)};
 
-  registry.SetWall(1000);
+  r.SetWall(1000);
   counter.Set(0);
 
-  registry.SetWall(61000);
+  r.SetWall(61000);
   counter.Set(100);
 
-  registry.SetWall(62000);
+  r.SetWall(62000);
   counter.Set(200);
 
-  registry.SetWall(121000);
-  auto ms1 = registry.measurements_for_name("ctr");
+  r.SetWall(121000);
+  auto ms1 = r.measurements_for_name("ctr");
   EXPECT_DOUBLE_EQ(200 / 60.0, ms1.at(0).value) << "Computes the correct rate";
 }
 
 TEST(MonotonicCounter, Expiration) {
-  TestRegistry registry;
-  MonotonicCounter counter{&registry, registry.CreateId("ctr", kEmptyTags)};
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  MonotonicCounter counter{&r, r.CreateId("ctr", kEmptyTags)};
 
-  registry.SetWall(61000);
+  r.SetWall(61000);
   counter.Set(100);
 
   EXPECT_FALSE(counter.HasExpired()) << "Recent update";
 
-  registry.SetWall(61000 + 14 * 60000);
+  r.SetWall(61000 + 14 * 60000);
   EXPECT_FALSE(counter.HasExpired()) << "Recent update";
 
-  registry.SetWall(61000 + 16 * 60000);
+  r.SetWall(61000 + 16 * 60000);
   EXPECT_TRUE(counter.HasExpired()) << "No recent update";
 
-  EXPECT_EQ(0, registry.measurements_for_name("ctr").size())
+  EXPECT_EQ(0, r.measurements_for_name("ctr").size())
       << "Expired metrics are not reported";
 }
 
 TEST(MonotonicCounter, Overflow) {
-  TestRegistry registry;
-  MonotonicCounter counter{&registry, registry.CreateId("ctr", kEmptyTags)};
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  MonotonicCounter counter{&r, r.CreateId("ctr", kEmptyTags)};
 
-  registry.SetWall(1000);
+  r.SetWall(1000);
   counter.Set(100);
-  registry.SetWall(61000);
+  r.SetWall(61000);
   counter.Set(200);
 
-  registry.SetWall(121000);
-  auto v = registry.measurements_for_name("ctr").front().value;
+  r.SetWall(121000);
+  auto v = r.measurements_for_name("ctr").front().value;
   EXPECT_DOUBLE_EQ(100 / 60.0, v);  // baseline
   counter.Set(100);
 
-  registry.SetWall(181000);
-  auto ov = registry.measurements_for_name("ctr").front().value;
+  r.SetWall(181000);
+  auto ov = r.measurements_for_name("ctr").front().value;
   EXPECT_DOUBLE_EQ(0.0, ov) << "Detects overflow in values";
 
-  registry.SetWall(241000);
+  r.SetWall(241000);
   counter.Set(200);
 
-  registry.SetWall(301000);
-  auto v2 = registry.measurements_for_name("ctr").front().value;
+  r.SetWall(301000);
+  auto v2 = r.measurements_for_name("ctr").front().value;
   EXPECT_DOUBLE_EQ(100 / 60.0, v2) << "Recovers from overflow";
 }

--- a/test/percentile_dist_summary_test.cc
+++ b/test/percentile_dist_summary_test.cc
@@ -8,9 +8,9 @@ using namespace atlas::meter;
 using atlas::util::intern_str;
 
 TEST(PercentileDistributionSummary, Percentile) {
-  TestRegistry registry;
-  PercentileDistributionSummary d{&registry,
-                                  registry.CreateId("foo", kEmptyTags)};
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  PercentileDistributionSummary d{&r, r.CreateId("foo", kEmptyTags)};
 
   for (auto i = 0; i < 100000; ++i) {
     d.Record(i);
@@ -24,13 +24,12 @@ TEST(PercentileDistributionSummary, Percentile) {
 }
 
 TEST(PercentileDistributionSummary, HasProperStatistic) {
-  TestRegistry registry;
-  PercentileDistributionSummary t{&registry,
-                                  registry.CreateId("foo", kEmptyTags)};
-
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  PercentileDistributionSummary t{&r, r.CreateId("foo", kEmptyTags)};
   t.Record(42);
 
-  auto ms = registry.meters();
+  auto ms = r.meters();
   auto percentileRef = intern_str("percentile");
   auto statisticRef = intern_str("statistic");
   for (const auto& m : ms) {
@@ -42,9 +41,9 @@ TEST(PercentileDistributionSummary, HasProperStatistic) {
 }
 
 TEST(PercentileDistributionSummary, CountTotal) {
-  TestRegistry registry;
-  PercentileDistributionSummary d{&registry,
-                                  registry.CreateId("foo", kEmptyTags)};
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  PercentileDistributionSummary d{&r, r.CreateId("foo", kEmptyTags)};
 
   for (auto i = 0; i < 100; ++i) {
     d.Record(i);

--- a/test/percentile_timer_test.cc
+++ b/test/percentile_timer_test.cc
@@ -6,8 +6,9 @@ using namespace atlas::meter;
 using atlas::util::intern_str;
 
 TEST(PercentileTimer, Percentile) {
-  TestRegistry registry;
-  PercentileTimer t{&registry, registry.CreateId("foo", kEmptyTags)};
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  PercentileTimer t{&r, r.CreateId("foo", kEmptyTags)};
 
   for (auto i = 0; i < 100000; ++i) {
     t.Record(std::chrono::milliseconds{i});
@@ -21,12 +22,13 @@ TEST(PercentileTimer, Percentile) {
 }
 
 TEST(PercentileTimer, HasProperStatistic) {
-  TestRegistry registry;
-  PercentileTimer t{&registry, registry.CreateId("foo", kEmptyTags)};
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  PercentileTimer t{&r, r.CreateId("foo", kEmptyTags)};
 
   t.Record(std::chrono::milliseconds{42});
 
-  auto ms = registry.meters();
+  auto ms = r.meters();
   auto percentileRef = intern_str("percentile");
   auto statisticRef = intern_str("statistic");
   for (const auto& m : ms) {
@@ -38,8 +40,9 @@ TEST(PercentileTimer, HasProperStatistic) {
 }
 
 TEST(PercentileTimer, CountTotal) {
-  TestRegistry registry;
-  PercentileTimer t{&registry, registry.CreateId("foo", kEmptyTags)};
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  PercentileTimer t{&r, r.CreateId("foo", kEmptyTags)};
 
   for (auto i = 0; i < 100; ++i) {
     t.Record(std::chrono::nanoseconds(i));

--- a/test/test_registry.h
+++ b/test/test_registry.h
@@ -5,9 +5,11 @@
 
 class TestRegistry : public atlas::meter::AtlasRegistry {
  public:
-  TestRegistry() : atlas::meter::AtlasRegistry(60000, &manual_clock) {}
+  TestRegistry(const atlas::meter::ManualClock* manual_clock)
+      : atlas::meter::AtlasRegistry(60000, manual_clock),
+        manual_clock_(manual_clock) {}
 
-  void SetWall(int64_t millis) { manual_clock.SetWall(millis); }
+  void SetWall(int64_t millis) { manual_clock_->SetWall(millis); }
 
   atlas::meter::Measurements measurements_for_name(const char* name) {
     auto ms = measurements();
@@ -19,6 +21,23 @@ class TestRegistry : public atlas::meter::AtlasRegistry {
     return mine;
   }
 
+  Meters my_meters() const {
+    auto ms = meters();
+    auto new_end = std::remove_if(
+        ms.begin(), ms.end(),
+        [](const std::shared_ptr<atlas::meter::Meter>& m) {
+          return atlas::util::StartsWith(m->GetId()->NameRef(), "atlas.");
+        });
+    ms.resize(std::distance(ms.begin(), new_end));
+    return ms;
+  }
+
+  const atlas::meter::ManualClock* manual_clock() const {
+    return manual_clock_;
+  }
+
+  void expire() { expire_meters(); }
+
  private:
-  atlas::meter::ManualClock manual_clock{};
+  const atlas::meter::ManualClock* manual_clock_;
 };


### PR DESCRIPTION
If there are no external references to expired meters, remove them from
the registry.

Fix test_registry so it takes a clock so it can be used by our super
class (needed for counters)