### PR TITLE
Make sure meters expire after calling measurements

### DIFF
--- a/test/atlas_registry_test.cc
+++ b/test/atlas_registry_test.cc
@@ -18,7 +18,7 @@ using atlas::interpreter::TagsValuePair;
 using atlas::interpreter::TagsValuePairs;
 using namespace atlas::meter;
 
-TEST(AtlasRegistry, Meters) {
+TEST(AtlasRegistry, MetersExpire) {
   ManualClock manual_clock;
   TestRegistry r{&manual_clock};
   r.SetWall(42);
@@ -45,4 +45,29 @@ TEST(AtlasRegistry, Meters) {
   r.expire();
   auto ms = r.my_meters();
   EXPECT_EQ(ms.size(), 1);
+}
+
+TEST(AtlasRegistry, MeasurementsExpire) {
+  ManualClock manual_clock;
+  TestRegistry r{&manual_clock};
+  r.SetWall(42);
+  Tags tags{{"k1", "v1"}, {"k2", "v2"}};
+  auto id1 = r.CreateId("m1", tags);
+  auto id3 = r.CreateId("m3", tags);
+  Tags tags_for_4{{"k1", "v1"}, {"k2", "v3"}};
+  auto id4 = r.CreateId("m3", tags_for_4);
+
+  auto ctr = r.counter(id1);
+  ctr->Increment();
+  // make sure we re-use ids
+  r.counter(r.CreateId("m2", tags))->Add(60);
+  r.counter(r.CreateId("m2", tags))->Add(60);
+  r.counter(id3)->Add(60);
+  r.counter(id4)->Add(60);
+
+  r.measurements();
+  r.SetWall(atlas::meter::MAX_IDLE_TIME + 43);
+  r.measurements();
+  auto meters = r.my_meters();
+  EXPECT_EQ(meters.size(), 1);
 }


### PR DESCRIPTION
Fix a bug where we were holding a copy of the meters, and making them
not be able to be removed from the registry