### PR TITLE
Use address sanitizer on travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 dist: trusty
-sudo: false
+sudo: true
 script: ./run-build.sh
 compiler:
   - clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ project(${PROJECT_NAME_STR})
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMakeModules)
 
+option (ASAN
+        "Build with address sanitizer enabled (ON) or disabled (OFF) - 2x slowdown when enabled"
+        OFF)
+
+# Code coverage for debug build
 string(TOLOWER ${CMAKE_BUILD_TYPE} LC_CMAKE_BUILD_TYPE)
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU AND LC_CMAKE_BUILD_TYPE STREQUAL debug)
   MESSAGE(STATUS "Setting up CodeCoverage")
@@ -14,7 +19,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL GNU AND LC_CMAKE_BUILD_TYPE STREQUAL debug)
   setup_target_for_coverage(${PROJECT_NAME}_coverage runtests coverage)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCURL_STATICLIB -DFMT_HEADER_ONLY -DSPDLOG_FMT_EXTERNAL -Werror -fno-rtti -Wall -Wno-missing-braces -fprofile-arcs -ftest-coverage")
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCURL_STATICLIB -DFMT_HEADER_ONLY -DSPDLOG_FMT_EXTERNAL -Werror -fno-rtti -Wall -Wno-missing-braces")
+  if (ASAN)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCURL_STATICLIB -DFMT_HEADER_ONLY -DSPDLOG_FMT_EXTERNAL -Werror -fno-rtti -Wall -Wno-missing-braces -fno-omit-frame-pointer -fsanitize=address")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCURL_STATICLIB -DFMT_HEADER_ONLY -DSPDLOG_FMT_EXTERNAL -Werror -fno-rtti -Wall -Wno-missing-braces")
+  endif()
 endif()
 
 include_directories(3rd-party ${CMAKE_CURRENT_BINARY_DIR})

--- a/run-build.sh
+++ b/run-build.sh
@@ -19,7 +19,7 @@ cd build
 if [ $CC = gcc ] ; then
   cmake -DCMAKE_BUILD_TYPE=Debug ..
 else
-  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DASAN=ON ..
 fi
 
 make -j4


### PR DESCRIPTION
When using travis enable the address sanitizer for clang builds. This
means we run two builds:

* gcc with code coverage and debug flags

* clang with address sanitizer checks and release flags

This should help us catch a wide variety of bugs, at the cost of a minor slow
down when running tests. When compiling this library for actual usage
ASAN should not be enabled to prevent a general slow down.