### PR TITLE
Add user-friendly function for validation checks

### DIFF
--- a/meter/publisher.cc
+++ b/meter/publisher.cc
@@ -95,7 +95,7 @@ rapidjson::Document MeasurementsToJson(
       continue;
     }
     auto tags = measure->all_tags();
-    if (validate && !validation::IsValid(tags)) {
+    if (validate && !AreTagsValid(tags)) {
       continue;
     }
     Value json_metric{kObjectType};

--- a/meter/validation.cc
+++ b/meter/validation.cc
@@ -7,7 +7,6 @@
 
 namespace atlas {
 namespace meter {
-namespace validation {
 
 static constexpr size_t MAX_KEY_LENGTH = 60;
 static constexpr size_t MAX_VAL_LENGTH = 120;
@@ -22,7 +21,7 @@ static bool is_key_restricted(StrRef k) noexcept {
   return StartsWith(k, "nf.") || StartsWith(k, "atlas.");
 }
 
-const std::unordered_set<StrRef>& valid_nf_tags() {
+static const std::unordered_set<StrRef>& valid_nf_tags() {
   static std::unordered_set<StrRef> kValidNfTags = {
       intern_str("nf.node"),          intern_str("nf.cluster"),
       intern_str("nf.app"),           intern_str("nf.asg"),
@@ -51,13 +50,13 @@ static bool is_user_key_invalid(StrRef k) noexcept {
   return false;
 }
 
-bool empty_or_null(StrRef r) { return r.is_null() || r.length() == 0; }
+static bool empty_or_null(StrRef r) { return r.is_null() || r.length() == 0; }
 
-bool IsValid(const Tags& tags) noexcept {
+bool AreTagsValid(const Tags& tags) noexcept {
   static auto kNameRef = intern_str("name");
 
   std::string err_msg;
-  size_t user_tags = 0;
+  auto user_tags = 0u;
   auto logger = util::Logger();
   auto name_seen = false;
 
@@ -122,6 +121,111 @@ invalid:
   return false;
 }
 
-}  // namespace validation
+ValidationIssues AnalyzeTags(const Tags& tags) noexcept {
+  static auto kNameRef = intern_str("name");
+  auto name_seen = false;
+  auto user_tags = 0u;
+
+  ValidationIssues result;
+  for (const auto& kv : tags) {
+    const auto& k_ref = kv.first;
+    const auto& v_ref = kv.second;
+
+    // check charset
+    auto validated_key = util::ToValidCharset(k_ref);
+    if (validated_key != k_ref) {
+      result.emplace(
+          ValidationIssue::Warn(fmt::format("Key: '{}' will be encoded as '{}'",
+                                            k_ref.get(), validated_key.get())));
+    }
+    auto validated_val = util::EncodeValueForKey(v_ref, k_ref);
+    if (validated_val != v_ref) {
+      result.emplace(ValidationIssue::Warn(
+          fmt::format("Value: '{}' for key '{}' will be encoded as '{}'",
+                      v_ref.get(), k_ref.get(), validated_val.get())));
+    }
+
+    if (empty_or_null(k_ref) || empty_or_null(v_ref)) {
+      result.emplace(
+          ValidationIssue::Err("Tag keys or values cannot be empty"));
+    }
+
+    if (k_ref == kNameRef) {
+      name_seen = true;
+      ++user_tags;
+      auto v_length = v_ref.length();
+      if (v_length > MAX_NAME_LENGTH) {
+        result.emplace(ValidationIssue::Err(
+            fmt::format("value for name exceeds length limit ({} > {})",
+                        v_length, MAX_NAME_LENGTH)));
+      }
+    } else {
+      auto k_length = k_ref.length();
+      auto v_length = v_ref.length();
+      if (k_length > MAX_KEY_LENGTH) {
+        result.emplace(ValidationIssue::Err(
+            fmt::format("Tag key '{}' exceeds length limits ({}-{})",
+                        k_ref.get(), k_length, MAX_KEY_LENGTH)));
+      }
+      if (v_length > MAX_VAL_LENGTH) {
+        result.emplace(ValidationIssue::Err(
+            fmt::format("Tag value '{}' exceeds length limits ({}-{})",
+                        v_ref.get(), v_length, MAX_VAL_LENGTH)));
+      }
+
+      if (!is_key_restricted(k_ref)) {
+        ++user_tags;
+      }
+
+      if (is_user_key_invalid(k_ref)) {
+        result.emplace(ValidationIssue::Err(fmt::format(
+            "Tag key '{}' is using a reserved namespace", k_ref.get())));
+      }
+    }
+  }
+
+  if (user_tags > MAX_USER_TAGS) {
+    result.emplace(
+        ValidationIssue::Err(fmt::format("Too many user tags. There is a limit "
+                                         "of {} user tags. Detected user tags "
+                                         "= {}",
+                                         MAX_USER_TAGS, user_tags)));
+  }
+
+  if (!name_seen) {
+    result.emplace(ValidationIssue::Err("name is a required tag"));
+  }
+  return result;
+}
+
+ValidationIssue ValidationIssue::Err(std::string message) noexcept {
+  ValidationIssue res;
+  res.level = ValidationIssue::Level::ERROR;
+  res.description = std::move(message);
+  return res;
+}
+
+ValidationIssue ValidationIssue::Warn(std::string message) noexcept {
+  ValidationIssue res;
+  res.level = ValidationIssue::Level::WARN;
+  res.description = std::move(message);
+  return res;
+}
+
+bool ValidationIssue::operator<(const ValidationIssue& rhs) const noexcept {
+  if (level < rhs.level) {
+    return true;
+  }
+  if (rhs.level < level) {
+    return false;
+  }
+  return description < rhs.description;
+}
+
+std::string ValidationIssue::ToString() const noexcept {
+  return fmt::format("{}: {}", level == Level::WARN ? "WARN" : "ERROR",
+                     description);
+}
+
 }  // namespace meter
 }  // namespace atlas

--- a/meter/validation.h
+++ b/meter/validation.h
@@ -1,15 +1,28 @@
 #pragma once
 
+#include <set>
 #include "id.h"
 
 namespace atlas {
 namespace meter {
-namespace validation {
 
 /// Return whether the given tags will pass validation rules done by our
 /// backends. It assumes we will fix invalid characters
-bool IsValid(const Tags& tags) noexcept;
+bool AreTagsValid(const Tags& tags) noexcept;
 
-}  // namespace validation
+struct ValidationIssue {
+  enum class Level { WARN, ERROR };
+  Level level;
+  std::string description;
+
+  bool operator<(const ValidationIssue& rhs) const noexcept;
+  std::string ToString() const noexcept;
+  static ValidationIssue Err(std::string message) noexcept;
+  static ValidationIssue Warn(std::string message) noexcept;
+};
+
+using ValidationIssues = std::set<ValidationIssue>;
+ValidationIssues AnalyzeTags(const Tags& tags) noexcept;
+
 }  // namespace meter
 }  // namespace atlas

--- a/test/validation_test.cc
+++ b/test/validation_test.cc
@@ -1,65 +1,68 @@
 #include "../meter/validation.h"
+#include "../util/logger.h"
 #include <gtest/gtest.h>
 
+using atlas::meter::AnalyzeTags;
+using atlas::meter::AreTagsValid;
 using atlas::meter::Tags;
-using atlas::meter::validation::IsValid;
+using atlas::meter::ValidationIssue;
 using atlas::util::intern_str;
 
 TEST(Validation, NoName) {
   Tags empty;
-  EXPECT_FALSE(IsValid(empty));
+  EXPECT_FALSE(AreTagsValid(empty));
 
   Tags some_random_tags{{"k1", "v1"}, {"k2", "v2"}};
-  EXPECT_FALSE(IsValid(some_random_tags));
+  EXPECT_FALSE(AreTagsValid(some_random_tags));
 
   Tags valid{{"name", "foobar"}};
-  EXPECT_TRUE(IsValid(valid));
+  EXPECT_TRUE(AreTagsValid(valid));
 }
 
 TEST(Validation, LongName) {
   std::string just_right(255, 'x');
   Tags just_right_name{{"name", just_right.c_str()}};
-  EXPECT_TRUE(IsValid(just_right_name));
+  EXPECT_TRUE(AreTagsValid(just_right_name));
 
   std::string too_long(256, 'x');
   Tags too_long_name{{"name", too_long.c_str()}};
-  EXPECT_FALSE(IsValid(too_long_name));
+  EXPECT_FALSE(AreTagsValid(too_long_name));
 }
 
 TEST(Validation, KeyLengths) {
   std::string key_just_right(60, 'k');
   Tags just_right{{"name", "foo"}, {key_just_right.c_str(), "x"}};
-  EXPECT_TRUE(IsValid(just_right));
+  EXPECT_TRUE(AreTagsValid(just_right));
 
   std::string key_too_long(61, 'k');
   Tags too_long{{"name", "foo"}, {key_too_long.c_str(), "v"}};
-  EXPECT_FALSE(IsValid(too_long));
+  EXPECT_FALSE(AreTagsValid(too_long));
 }
 
 TEST(Validation, EmptyKeyOrValue) {
   Tags empty_name{{"name", ""}, {"k", "v"}, {"k2", "v2"}};
-  EXPECT_FALSE(IsValid(empty_name));
+  EXPECT_FALSE(AreTagsValid(empty_name));
 
   Tags empty_key{{"name", "n"}, {"", "v"}, {"k2", "v"}};
-  EXPECT_FALSE(IsValid(empty_key));
+  EXPECT_FALSE(AreTagsValid(empty_key));
 
   Tags empty_value{{"name", "n"}, {"k1", ""}, {"k2", ""}, {"k3", "v"}};
-  EXPECT_FALSE(IsValid(empty_value));
+  EXPECT_FALSE(AreTagsValid(empty_value));
 }
 
 TEST(Validation, InvalidKey) {
   Tags uses_atlas_ns{
       {"name", "n"}, {"atlas.rules", "true"}, {"atlas.legacy", "epic"}};
-  EXPECT_FALSE(IsValid(uses_atlas_ns));
+  EXPECT_FALSE(AreTagsValid(uses_atlas_ns));
 
   Tags uses_nf_ns{{"name", "n"}, {"nf.country", "us"}, {"nf.legacy", "epic"}};
-  EXPECT_FALSE(IsValid(uses_nf_ns));
+  EXPECT_FALSE(AreTagsValid(uses_nf_ns));
 
   Tags uses_valid_atlas{{"atlas.dstype", "counter"}, {"name", "n"}};
-  EXPECT_TRUE(IsValid(uses_valid_atlas));
+  EXPECT_TRUE(AreTagsValid(uses_valid_atlas));
 
   Tags uses_valid_nf{{"nf.country", "ar"}, {"name", "n"}};
-  EXPECT_TRUE(IsValid(uses_valid_nf));
+  EXPECT_TRUE(AreTagsValid(uses_valid_nf));
 }
 
 TEST(Validation, TooManyUserTags) {
@@ -69,8 +72,108 @@ TEST(Validation, TooManyUserTags) {
   for (auto i = 1; i < 20; ++i) {
     tags.add(std::to_string(i).c_str(), "v");
   }
-  EXPECT_TRUE(IsValid(tags));
+  EXPECT_TRUE(AreTagsValid(tags));
 
   tags.add("extra", "v");
-  EXPECT_FALSE(IsValid(tags));
+  EXPECT_FALSE(AreTagsValid(tags));
+}
+
+TEST(ValidationA, NoName) {
+  Tags empty;
+  auto res = AnalyzeTags(empty);
+  EXPECT_EQ(res.size(), 1);
+
+  Tags some_random_tags{{"k1", "v1"}, {"k2", "v2"}};
+  res = AnalyzeTags(some_random_tags);
+  EXPECT_EQ(res.size(), 1);
+
+  Tags valid{{"name", "foobar"}};
+  EXPECT_TRUE(AnalyzeTags(valid).empty());
+}
+
+TEST(ValidationA, LongName) {
+  std::string just_right(255, 'x');
+  Tags just_right_name{{"name", just_right.c_str()}};
+  EXPECT_TRUE(AnalyzeTags(just_right_name).empty());
+
+  std::string too_long(256, 'x');
+  Tags too_long_name{{"name", too_long.c_str()}};
+  auto res = AnalyzeTags(too_long_name);
+  EXPECT_EQ(res.size(), 1);
+}
+
+TEST(ValidationA, KeyLengths) {
+  std::string key_just_right(60, 'k');
+  Tags just_right{{"name", "foo"}, {key_just_right.c_str(), "x"}};
+  EXPECT_TRUE(AnalyzeTags(just_right).empty());
+
+  std::string key_too_long(61, 'k');
+  Tags too_long{{"name", "foo"}, {key_too_long.c_str(), "v"}};
+  auto res = AnalyzeTags(too_long);
+  EXPECT_EQ(res.size(), 1);
+}
+
+TEST(ValidationA, EmptyKeyOrValue) {
+  Tags empty_name{{"name", ""}, {"k", "v"}, {"k2", "v2"}};
+  auto res = AnalyzeTags(empty_name);
+  EXPECT_EQ(res.size(), 1);
+  Tags empty_key{{"name", "n"}, {"", "v"}, {"k2", "v"}};
+  res = AnalyzeTags(empty_key);
+  EXPECT_EQ(res.size(), 1);
+
+  Tags empty_value{{"name", "n"}, {"k1", ""}, {"k2", ""}, {"k3", "v"}};
+  res = AnalyzeTags(empty_value);
+  EXPECT_EQ(res.size(), 1);
+}
+
+TEST(ValidationA, InvalidKey) {
+  Tags uses_atlas_ns{
+      {"name", "n"}, {"atlas.rules", "true"}, {"atlas.legacy", "epic"}};
+  auto res = AnalyzeTags(uses_atlas_ns);
+  EXPECT_EQ(res.size(), 1);
+
+  Tags uses_nf_and_atlas_ns{{"name", "n"},
+                            {"nf.country", "us"},
+                            {"nf.legacy", "epic"},
+                            {"atlas.x", "foo"}};
+  res = AnalyzeTags(uses_nf_and_atlas_ns);
+  EXPECT_EQ(res.size(), 2);
+
+  Tags uses_valid_atlas{{"atlas.dstype", "counter"}, {"name", "n"}};
+  EXPECT_TRUE(AnalyzeTags(uses_valid_atlas).empty());
+
+  Tags uses_valid_nf{{"nf.country", "ar"}, {"name", "n"}};
+  EXPECT_TRUE(AnalyzeTags(uses_valid_nf).empty());
+}
+
+TEST(ValidationA, TooManyUserTags) {
+  Tags tags = {
+      {"name", "n"}, {"atlas.dstype", "counter"}, {"nf.country", "us"}};
+
+  for (auto i = 1; i < 20; ++i) {
+    tags.add(std::to_string(i).c_str(), "v");
+  }
+  EXPECT_TRUE(AnalyzeTags(tags).empty());
+
+  tags.add("extra", "v");
+  auto res = AnalyzeTags(tags);
+  EXPECT_EQ(res.size(), 1);
+  for (auto& issue : res) {
+    atlas::util::Logger()->info("{}", issue.ToString());
+  }
+}
+
+TEST(ValidationA, Warnings) {
+  Tags tags = {{"name", "n~1"},
+               {"nf.asg", "foo~1"},
+               {"atlas.dstype", "foo bar"},
+               {"nf.country", "us#1"},
+               {"blah ", "bar"}};
+
+  auto res = AnalyzeTags(tags);
+  EXPECT_EQ(res.size(), 4);
+  for (auto& issue : res) {
+    EXPECT_EQ(issue.level, ValidationIssue::Level::WARN);
+    atlas::util::Logger()->info("{}", issue.ToString());
+  }
 }


### PR DESCRIPTION
Adds a function that can be used by users to get a list of errors or
warnings that were generated when validation is performed on some Tags
(including the 'name' key as part of the tags).

This will be used by the node-client when running in a dev setting