### PR TITLE
Improve validation error messages

### DIFF
--- a/meter/validation.cc
+++ b/meter/validation.cc
@@ -145,9 +145,15 @@ ValidationIssues AnalyzeTags(const Tags& tags) noexcept {
                       v_ref.get(), k_ref.get(), validated_val.get())));
     }
 
-    if (empty_or_null(k_ref) || empty_or_null(v_ref)) {
-      result.emplace(
-          ValidationIssue::Err("Tag keys or values cannot be empty"));
+    if (empty_or_null(k_ref) && empty_or_null(v_ref)) {
+      result.emplace(ValidationIssue::Err(
+          "Tags cannot be empty. Found empty key and value."));
+    } else if (empty_or_null(k_ref)) {
+      result.emplace(ValidationIssue::Err(
+          fmt::format("Empty key found with value '{}'", v_ref.get())));
+    } else if (empty_or_null(v_ref)) {
+      result.emplace(ValidationIssue::Err(
+          fmt::format("Tag value for key '{}' cannot be empty", k_ref.get())));
     }
 
     if (k_ref == kNameRef) {

--- a/test/validation_test.cc
+++ b/test/validation_test.cc
@@ -123,7 +123,7 @@ TEST(ValidationA, EmptyKeyOrValue) {
 
   Tags empty_value{{"name", "n"}, {"k1", ""}, {"k2", ""}, {"k3", "v"}};
   res = AnalyzeTags(empty_value);
-  EXPECT_EQ(res.size(), 1);
+  EXPECT_EQ(res.size(), 2);
 }
 
 TEST(ValidationA, InvalidKey) {


### PR DESCRIPTION
Include the name of the key for which there is no value, or the value if
the key is empty. Makes it easier to track the source of an error.