### PR TITLE
Remove notifyAlertServer support

### DIFF
--- a/resources/atlas-config-reference.json
+++ b/resources/atlas-config-reference.json
@@ -5,8 +5,6 @@
   "evaluateUrl": "http://atlas-lwcapi-iep.$EC2_REGION.iep$NETFLIX_ENVIRONMENT.netflix.net/lwc/api/v1/evaluate",
   "subscriptionsUrl": "http://atlas-lwcapi-iep.$EC2_REGION.iep$NETFLIX_ENVIRONMENT.netflix.net/lwc/api/v1/$NETFLIX_AUTO_SCALE_GROUP",
   "publishUrl": "http://atlas-pub-$EC2_OWNER_ID.$EC2_REGION.$NETFLIX_ACCOUNT.netflix.net/api/v1/publish-fast",
-  "checkClusterUrl": "http://atlas-alert-api-$EC2_OWNER_ID.$EC2_REGION.$NETFLIX_ENVIRONMENT.netflix.net/alertchecker/checkCluster/$NETFLIX_CLUSTER",
-  "notifyAlertServer": true,
   "publishConfig": [
     ":true,:all"
   ],

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -81,8 +81,7 @@ TEST(EndpointConfig, ParseAndCompose) {
   const char* cfgStr = R"json(
       {"evaluateUrl": "http://foo.$EndpointConfigTest.bar/eval",
        "subscriptionsUrl": "http://foo.$EndpointConfigTest.bar/subs",
-       "publishUrl": "http://foo.$EndpointConfigTest.bar/pub",
-       "checkClusterUrl": "http://foo.$EndpointConfigTest.bar/check"
+       "publishUrl": "http://foo.$EndpointConfigTest.bar/pub"
       })json";
   rapidjson::Document document;
   document.Parse(cfgStr);
@@ -103,7 +102,6 @@ TEST(EndpointConfig, ParseAndCompose) {
 TEST(Features, Parse) {
   const char* cfgStr = R"json(
       {"validateMetrics": false,
-       "notifyAlertServer": false,
        "publishConfig": ["class,:has,:all", ":true,(,nf.node,),:drop-tags"],
        "forceStart": true,
        "publishEnabled": true,

--- a/test/resources/config.json
+++ b/test/resources/config.json
@@ -3,7 +3,5 @@
   "publishUrl": "http://atlas.example.com/pub",
   "evaluateUrl": "http://atlas.example.com/eval",
   "subscriptionsUrl": "http://atlas.example.com/subs",
-  "checkClusterUrl": "http://atlas.example.com/check",
-  "notifyAlertServer": false,
   "dumpMetrics": true
 }

--- a/util/config_manager.cc
+++ b/util/config_manager.cc
@@ -101,9 +101,5 @@ void ConfigManager::AddCommonTag(const char* key, const char* value) noexcept {
   extra_tags_.add(key, value);
 }
 
-void ConfigManager::SetNotifyAlertServer(bool notify) noexcept {
-  default_notify_ = notify;
-}
-
 }  // namespace util
 }  // namespace atlas

--- a/util/config_manager.h
+++ b/util/config_manager.h
@@ -30,8 +30,6 @@ class ConfigManager {
 
   void AddCommonTag(const char* key, const char* value) noexcept;
 
-  void SetNotifyAlertServer(bool notify) noexcept;
-
  private:
   mutable std::mutex config_mutex;
   std::mutex cv_mutex;
@@ -41,7 +39,6 @@ class ConfigManager {
   std::shared_ptr<Config> current_config_;
   std::atomic<bool> should_run_{false};
   meter::Tags extra_tags_;
-  bool default_notify_ = true;
 
   void refresher() noexcept;
   void refresh_configs() noexcept;


### PR DESCRIPTION
This was a hack that was in place to let our Netflix alert server know
that the client didn't support on-instance evaluation of alerts. This is
no longer needed.