### PR TITLE
Fix flushing of metrics at shutdown

### DIFF
--- a/atlas_client.cc
+++ b/atlas_client.cc
@@ -33,7 +33,7 @@ class Client::impl {
   impl()
       : started{false},
         config_manager{util::kLocalFileName, util::kConfigRefreshMillis},
-        subscription_manager{config_manager} {}
+        subscription_manager{&clock, config_manager} {}
 
   ~impl() {
     if (started) {
@@ -67,7 +67,7 @@ class Client::impl {
     auto logger = Logger();
     if (started) {
       logger->info("Stopping atlas-client");
-      subscription_manager.Stop(&clock);
+      subscription_manager.Stop();
       config_manager.Stop();
       started = false;
       http::global_shutdown();

--- a/main.cc
+++ b/main.cc
@@ -6,28 +6,18 @@
 
 using namespace atlas::meter;
 
-void init_tags(Tags* tags) {
-  std::string prefix{"some.random.string.for.testing."};
-  const char* value = "some.random.value.for.testing";
-  for (int i = 0; i < 10; ++i) {
-    tags->add((prefix + std::to_string(i)).c_str(), value);
-  }
-}
-
 int main(int argc, char* argv[]) {
   atlas::util::UseConsoleLogger(1);
   atlas::Client atlas_client;
   atlas_client.Start();
   auto registry = atlas_client.GetRegistry();
 
-  Tags test_tags;
-  init_tags(&test_tags);
-  std::string prefix{"atlas.client.test."};
+  std::string name{"test.counter"};
   auto logger = atlas::util::Logger();
   for (int second = 0; second < 60; ++second) {
-    auto name = prefix + std::to_string(1);
-    logger->info("Incrementing {}", name);
     registry->counter(name, kEmptyTags)->Increment();
+    logger->info("Incrementing test.counter: {} ({})", second + 1,
+                 (second + 1) / 60.0);
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
   logger->info("Shutting down");

--- a/meter/atlas_registry.cc
+++ b/meter/atlas_registry.cc
@@ -16,8 +16,6 @@
 namespace atlas {
 namespace meter {
 
-SystemClock system_clock;
-
 // we mostly use this class to avoid adding an external dependency to
 // the interpreter from our public headers
 class AtlasRegistry::impl {

--- a/meter/atlas_registry.h
+++ b/meter/atlas_registry.h
@@ -10,15 +10,12 @@ namespace atlas {
 
 namespace meter {
 
-extern SystemClock system_clock;
-
 class AtlasRegistry : public Registry {
   class impl;
   std::unique_ptr<impl> impl_;
 
  public:
-  explicit AtlasRegistry(int64_t freq_millis,
-                         const Clock* clock = &system_clock) noexcept;
+  AtlasRegistry(int64_t freq_millis, const Clock* clock) noexcept;
 
   AtlasRegistry(const AtlasRegistry& registry) = delete;
   ~AtlasRegistry() override;

--- a/meter/consolidation_registry.cc
+++ b/meter/consolidation_registry.cc
@@ -61,6 +61,10 @@ void ConsolidationRegistry::update_from(
   for (const auto& m : measurements) {
     auto& my_m = my_measures[m.id];
     my_m.id = m.id;
+    if (my_m.timestamp == m.timestamp) {
+      // duplicate update
+      continue;
+    }
     my_m.timestamp = m.timestamp;
     auto op = aggregate_op(m);
     switch (op) {
@@ -84,8 +88,9 @@ Measurements ConsolidationRegistry::measurements() const noexcept {
   for (const auto& m : my_measures) {
     result.push_back(m.second);
   }
-  Logger()->debug("Returning {} measurements, and resetting aggregate registry",
-                  result.size());
+  Logger()->debug(
+      "Returning {} measurements, and resetting consolidation registry",
+      result.size());
   my_measures.clear();
   return result;
 }

--- a/meter/subscription_manager.h
+++ b/meter/subscription_manager.h
@@ -17,8 +17,8 @@ using ParsedSubscriptions = std::array<Subscriptions, util::kMainMultiple>;
 
 class SubscriptionManager {
  public:
-  explicit SubscriptionManager(
-      const util::ConfigManager& config_manager) noexcept;
+  SubscriptionManager(SystemClockWithOffset* clock,
+                      const util::ConfigManager& config_manager) noexcept;
   ~SubscriptionManager();
 
   SubscriptionManager(const SubscriptionManager&) = delete;
@@ -27,7 +27,7 @@ class SubscriptionManager {
 
   void Start() noexcept;
 
-  void Stop(SystemClockWithOffset* clock = nullptr) noexcept;
+  void Stop() noexcept;
 
   void PushMeasurements(int64_t now_millis,
                         const interpreter::TagsValuePairs& measurements) const;
@@ -35,6 +35,7 @@ class SubscriptionManager {
   std::shared_ptr<Registry> GetRegistry() { return registry_; }
 
  private:
+  SystemClockWithOffset* clock_;
   interpreter::Evaluator evaluator_;
   const util::ConfigManager& config_manager_;
   std::shared_ptr<Registry> registry_;  // 5s registry
@@ -66,6 +67,8 @@ class SubscriptionManager {
   // for testing
   void refresh_subscriptions(const std::string& subs_endpoint);
   void send_to_main();
+  void flush_metrics() noexcept;
+  void update_registries() noexcept;
 };
 }  // namespace meter
 }  // namespace atlas


### PR DESCRIPTION
Make sure the client sends any partial updates to the main publish path,
and to all subscriptions at shutdown