### PR TITLE
Use 'in situ' json parser for subscriptions

### DIFF
--- a/bench/code/parse_json.cc
+++ b/bench/code/parse_json.cc
@@ -2,19 +2,16 @@
 #include <benchmark/benchmark.h>
 #include "../../meter/subscription.h"
 
-// Reading the rapidjson docs suggests that using ParseInsitu(buffer) is more
-// efficient than Parse(read-only-buffer)
-//
-// Running the benchmark shows that it's not faster, even though the gains might
-// be related to just avoiding memory allocations
+// rapidjson::Document::ParseInsitu(buffer) is more efficient than the
+// Parse version (by around 12-13% on a payload with around 30k subscriptions)
 //
 // Run on (8 X 2793.31 MHz CPU s)
-// 2018-07-13 16:41:30
+// 2018-07-13 22:00:56
 // --------------------------------------------------
 // Benchmark           Time           CPU Iterations
 // --------------------------------------------------
-// BM_insitu         115 ns        115 ns    6069279
-// BM_copy           101 ns        101 ns    6938868
+// BM_insitu    37849961 ns   37850002 ns         19
+// BM_copy      43675883 ns   43676134 ns         16
 
 using atlas::meter::Subscription;
 using atlas::meter::Subscriptions;
@@ -24,8 +21,9 @@ char* read_file(const char* fname) {
   assert(fp != nullptr);
   fseek(fp, 0, SEEK_END);
   auto filesize = static_cast<size_t>(ftell(fp));
+  fseek(fp, 0, SEEK_SET);
   auto buffer = static_cast<char*>(malloc(filesize + 1));
-  auto readLength = fread(buffer, filesize, 1, fp);
+  auto readLength = fread(buffer, 1, filesize, fp);
   buffer[readLength] = '\0';
   fclose(fp);
   return buffer;

--- a/meter/subscription_manager.cc
+++ b/meter/subscription_manager.cc
@@ -151,13 +151,11 @@ void SubscriptionManager::sub_refresher() noexcept {
   }
 }
 
-ParsedSubscriptions ParseSubscriptions(const std::string& subs_str) {
+ParsedSubscriptions ParseSubscriptions(char* subs_buffer) {
   using rapidjson::Document;
-  using rapidjson::kParseCommentsFlag;
-  using rapidjson::kParseNanAndInfFlag;
 
   Document document;
-  document.Parse(subs_str.c_str());
+  document.ParseInsitu(subs_buffer);
   ParsedSubscriptions subs;
   auto logger = Logger();
   if (document.IsObject()) {
@@ -207,7 +205,8 @@ void SubscriptionManager::refresh_subscriptions(
   timer_refresh_subs->Record(registry_->clock().MonotonicTime() - start);
   if (http_res == 200) {
     try {
-      auto subscriptions = ParseSubscriptions(subs_str);
+      auto subscriptions =
+          ParseSubscriptions(const_cast<char*>(subs_str.c_str()));
       std::lock_guard<std::mutex> guard{subscriptions_mutex};
       subscriptions_ = std::move(subscriptions);
     } catch (...) {

--- a/test/subscriptions_manager_test.cc
+++ b/test/subscriptions_manager_test.cc
@@ -15,7 +15,7 @@ SubscriptionResults generate_sub_results(
     const interpreter::Evaluator& evaluator, const Subscriptions& subs,
     const interpreter::TagsValuePairs& pairs);
 
-ParsedSubscriptions ParseSubscriptions(const std::string& subs_str);
+ParsedSubscriptions ParseSubscriptions(char* subs_buffer);
 rapidjson::Document MeasurementsToJson(
     int64_t now_millis,
     const interpreter::TagsValuePairs::const_iterator& first,
@@ -36,7 +36,7 @@ TEST(SubscriptionsManager, ParseSubs) {
   std::stringstream buffer;
   buffer << one_sub.rdbuf();
 
-  auto subs = ParseSubscriptions(buffer.str());
+  auto subs = ParseSubscriptions(const_cast<char*>(buffer.str().c_str()));
   auto expected = Subscriptions{
       Subscription{"So3yA1c1xN_vzZASUQdORBqd9hM", kMainFrequencyMillis,
                    "nf.cluster,skan-test,:eq,name,foometric,:eq,:and,:sum"},
@@ -53,7 +53,7 @@ TEST(SubscriptionsManager, ParseLotsOfSubs) {
 
   Logger()->set_level(spdlog::level::info);
   // this is very spammy since it'll output all the subscriptions
-  auto subs = ParseSubscriptions(buffer.str());
+  auto subs = ParseSubscriptions(const_cast<char*>(buffer.str().c_str()));
   Logger()->set_level(spdlog::level::debug);
   EXPECT_EQ(subs[kMainMultiple - 1].size(), 3665);
 }
@@ -136,7 +136,7 @@ TEST(SubscriptionManager, SubResToJson) {
       "\"v2\",\"name\":\"n1\"},\"value\":24.0}]}";
 
   Document expected_json;
-  expected_json.Parse<kParseCommentsFlag | kParseNanAndInfFlag>(expected);
+  expected_json.Parse(expected);
   expect_eq_json(expected_json, json);
 }
 


### PR DESCRIPTION
Fixed the benchmark which wasn't actually reading the files, and after
running it showed that the insitu version is around 12-13% faster. Use
this version for reduced mem allocations and the extra speed.