### PR TITLE
Tests for query dnf

### DIFF
--- a/interpreter/query.cc
+++ b/interpreter/query.cc
@@ -413,6 +413,7 @@ std::vector<std::shared_ptr<Query>> query::dnf_list(
       } else {
         res.emplace_back(query);
       }
+      break;
     }
     default: { res.emplace_back(query); }
   }

--- a/interpreter/query.h
+++ b/interpreter/query.h
@@ -270,7 +270,8 @@ class OrQuery : public Query {
   bool Equals(const Query& query) const noexcept override {
     if (query.GetQueryType() != QueryType::Or) return false;
     const auto& q = static_cast<const OrQuery&>(query);
-    return q.q1_->Equals(*q1_) && q.q2_->Equals(*q2_);
+    return (q.q1_->Equals(*q1_) && q.q2_->Equals(*q2_)) ||
+           (q.q2_->Equals(*q1_) && q.q1_->Equals(*q2_));
   }
 
   size_t Hash() const noexcept override {
@@ -298,7 +299,9 @@ class AndQuery : public Query {
   bool Equals(const Query& query) const noexcept override {
     if (query.GetQueryType() != QueryType::And) return false;
     const auto& q = static_cast<const AndQuery&>(query);
-    return q.q1_->Equals(*q1_) && q.q2_->Equals(*q2_);
+    // a and b == b and a
+    return (q.q1_->Equals(*q1_) && q.q2_->Equals(*q2_)) ||
+           (q.q1_->Equals(*q2_) && q.q2_->Equals(*q1_));
   }
 
   size_t Hash() const noexcept override {

--- a/test/query_utils.h
+++ b/test/query_utils.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <vector>
+#include <unordered_set>
+#include "../interpreter/query.h"
+
+using atlas::interpreter::Query;
+using atlas::interpreter::QueryType;
+using QueryPtr = std::shared_ptr<Query>;
+using Queries = std::vector<QueryPtr>;
+
+inline std::string queries_to_str(const Queries& qs) {
+  std::ostringstream os;
+  os << '[';
+  auto first = true;
+  for (const auto& q : qs) {
+    if (first) {
+      first = false;
+    } else {
+      os << ',';
+    }
+    q->Dump(os);
+  }
+  os << ']';
+  return os.str();
+}
+
+inline std::string query_to_str(const Query& q) {
+  std::ostringstream os;
+  q.Dump(os);
+  return os.str();
+}
+
+inline void expect_eq_queries(Queries& lhs, Queries& rhs) {
+  if (lhs.size() != rhs.size()) {
+    FAIL() << "lhs.size()=" << lhs.size() << " != rhs.size()=" << rhs.size()
+           << "\n"
+           << queries_to_str(lhs) << " != " << queries_to_str(rhs);
+  }
+
+  auto i = 0u;
+  for (const auto& q1 : lhs) {
+    auto& q2 = rhs[i++];
+    if (!q1->Equals(*q2)) {
+      FAIL() << query_to_str(*q1) << " != " << query_to_str(*q2) << "\n"
+             << queries_to_str(lhs) << " !=\n"
+             << queries_to_str(rhs);
+    }
+  }
+}


### PR DESCRIPTION
Test the disjunctive normal form generated by different combinations of
queries. Caught a bug with handling `not` queries (missing `break`)