### PR TITLE
Remove test dir from code coverage report

### DIFF
--- a/create-lcov-report.sh
+++ b/create-lcov-report.sh
@@ -7,6 +7,6 @@ echo $PWD
 # capture coverage info
 lcov --directory . --capture --output-file coverage.info
 # filter out system, build, tests and 3rd-party code from our test coverage
-lcov --remove coverage.info '/usr/*' '*/usr/*' '*/3rd-party/*' '*/build/*' '*/test/*'--output-file coverage.info
+lcov --remove coverage.info '/usr/*' '*/usr/*' '*/3rd-party/*' '*/build/*' '*/test/*' --output-file coverage.info
 # print report to stdout for debugging
 lcov --list coverage.info


### PR DESCRIPTION
A typo was preventing it from getting removed