### PR TITLE
Add Query Index

### DIFF
--- a/interpreter/query.cc
+++ b/interpreter/query.cc
@@ -1,8 +1,8 @@
 #include <numeric>
 #include "query.h"
 #include "../meter/id.h"
+#include "../util/collections.h"
 #include "../util/logger.h"
-#include "../util/vector.h"
 
 namespace atlas {
 namespace interpreter {

--- a/interpreter/query.h
+++ b/interpreter/query.h
@@ -321,6 +321,10 @@ inline std::unique_ptr<Query> eq(const char* k, const char* v) noexcept {
                                       RelOp::EQ);
 }
 
+inline std::unique_ptr<Query> has(const char* k) noexcept {
+  return std::make_unique<HasKeyQuery>(util::intern_str(k));
+}
+
 inline std::unique_ptr<Query> in(const char* k, StringRefs vs) noexcept {
   auto unique_vs = std::make_unique<StringRefs>(std::move(vs));
   return std::make_unique<InQuery>(util::intern_str(k), std::move(unique_vs));
@@ -390,19 +394,33 @@ std::vector<std::shared_ptr<Query>> dnf_list(std::shared_ptr<Query> query);
 
 namespace std {
 template <>
-struct hash<atlas::interpreter::RelopQuery> {
-  size_t operator()(const atlas::interpreter::RelopQuery& query) const {
-    auto k = std::hash<atlas::util::StrRef>()(query.KeyRef());
-    auto v = std::hash<atlas::util::StrRef>()(query.ValueRef());
-    return k ^ v;
+struct hash<shared_ptr<atlas::interpreter::Query>> {
+  size_t operator()(const shared_ptr<atlas::interpreter::Query>& query) const {
+    return query->Hash();
   }
 };
 
 template <>
-struct equal_to<atlas::interpreter::RelopQuery> {
-  bool operator()(const atlas::interpreter::RelopQuery& lhs,
-                  const atlas::interpreter::RelopQuery& rhs) const {
-    return lhs.Equals(rhs);
+struct equal_to<shared_ptr<atlas::interpreter::Query>> {
+  bool operator()(const shared_ptr<atlas::interpreter::Query>& lhs,
+                  const shared_ptr<atlas::interpreter::Query>& rhs) const {
+    return lhs->Equals(*rhs);
+  }
+};
+
+template <>
+struct hash<shared_ptr<atlas::interpreter::RelopQuery>> {
+  size_t operator()(
+      const shared_ptr<atlas::interpreter::RelopQuery>& query) const {
+    return query->Hash();
+  }
+};
+
+template <>
+struct equal_to<shared_ptr<atlas::interpreter::RelopQuery>> {
+  bool operator()(const shared_ptr<atlas::interpreter::RelopQuery>& lhs,
+                  const shared_ptr<atlas::interpreter::RelopQuery>& rhs) const {
+    return lhs->Equals(*rhs);
   }
 };
 

--- a/interpreter/query_index.h
+++ b/interpreter/query_index.h
@@ -1,0 +1,429 @@
+#pragma once
+
+#include <ska/flat_hash_map.hpp>
+#include <unordered_set>
+#include <ostream>
+#include <sstream>
+#include <iostream>
+#include <utility>
+#include "query.h"
+#include "../util/collections.h"
+#include "../util/logger.h"
+namespace atlas {
+namespace interpreter {
+
+template <typename T>
+struct QueryIndexEntry {
+  std::shared_ptr<Query> query;
+  T value;
+};
+
+template <typename T>
+class QueryIndexAnnotated {
+ public:
+  using Filters = ska::flat_hash_set<std::shared_ptr<RelopQuery>>;
+  QueryIndexAnnotated(QueryIndexEntry<T> e, Filters f) noexcept
+      : entry{std::move(e)}, filters{std::move(f)} {}
+
+  QueryIndexEntry<T> entry;
+  Filters filters;
+
+  std::vector<std::pair<std::shared_ptr<RelopQuery>, QueryIndexAnnotated<T>>>
+  to_query_annotated_list() const {
+    std::vector<std::pair<std::shared_ptr<RelopQuery>, QueryIndexAnnotated<T>>>
+        res;
+    res.reserve(filters.size());
+    for (const auto& filter : filters) {
+      Filters new_filters{filters};
+      new_filters.erase(filter);
+      res.emplace_back(std::make_pair(
+          filter, QueryIndexAnnotated{entry, std::move(new_filters)}));
+    }
+    return res;
+  }
+
+  std::string to_string() const {
+    std::ostringstream os;
+    os << "(entry.query=";
+    entry.query->Dump(os);
+    os << ", filters=[";
+    auto first = true;
+    for (const auto& f : filters) {
+      if (first) {
+        first = false;
+      } else {
+        os << ',';
+      }
+      f->Dump(os);
+    }
+    os << "])";
+    return os.str();
+  }
+};
+
+}  // namespace interpreter
+}  // namespace atlas
+
+namespace std {
+template <typename T>
+struct hash<atlas::interpreter::QueryIndexEntry<T>> {
+  size_t operator()(const atlas::interpreter::QueryIndexEntry<T>& a) const {
+    return a.query->Hash() ^ hash<T>()(a.value);
+  }
+};
+
+template <typename T>
+struct equal_to<atlas::interpreter::QueryIndexEntry<T>> {
+  bool operator()(const atlas::interpreter::QueryIndexEntry<T>& lhs,
+                  const atlas::interpreter::QueryIndexEntry<T>& rhs) const {
+    return lhs.query->Equals(*rhs.query) && equal_to<T>()(lhs.value, rhs.value);
+  }
+};
+
+template <typename T>
+struct hash<atlas::interpreter::QueryIndexAnnotated<T>> {
+  size_t operator()(const atlas::interpreter::QueryIndexAnnotated<T>& a) const {
+    auto res = hash<atlas::interpreter::QueryIndexEntry<T>>()(a.entry);
+    for (const auto& f : a.filters) {
+      res <<= 1;
+      res ^= f->Hash();
+    }
+    return res;
+  }
+};
+
+template <typename T>
+struct equal_to<atlas::interpreter::QueryIndexAnnotated<T>> {
+  bool operator()(const atlas::interpreter::QueryIndexAnnotated<T>& lhs,
+                  const atlas::interpreter::QueryIndexAnnotated<T>& rhs) const {
+    bool eq_entries = equal_to<atlas::interpreter::QueryIndexEntry<T>>()(
+        lhs.entry, rhs.entry);
+    if (!eq_entries) return false;
+
+    if (lhs.filters.size() != rhs.filters.size()) {
+      return false;
+    }
+
+    for (const auto& f : lhs.filters) {
+      auto found = rhs.filters.find(f) != rhs.filters.end();
+      if (!found) return false;
+    }
+
+    return true;
+  }
+};
+
+template <typename T>
+struct hash<vector<atlas::interpreter::QueryIndexAnnotated<T>>> {
+  size_t operator()(
+      const vector<atlas::interpreter::QueryIndexAnnotated<T>>& v) const {
+    auto res = static_cast<size_t>(0);
+    for (const auto& e : v) {
+      res = (res << 4u) ^
+            std::hash<atlas::interpreter::QueryIndexAnnotated<T>>()(e);
+    }
+    return res;
+  }
+};
+
+template <typename T>
+struct equal_to<vector<atlas::interpreter::QueryIndexAnnotated<T>>> {
+  bool operator()(
+      const vector<atlas::interpreter::QueryIndexAnnotated<T>>& lhs,
+      const vector<atlas::interpreter::QueryIndexAnnotated<T>>& rhs) const {
+    if (lhs.size() != rhs.size()) return false;
+    for (auto i = 0u; i < lhs.size(); ++i) {
+      if (!equal_to<atlas::interpreter::QueryIndexAnnotated<T>>()(lhs[i],
+                                                                  rhs[i]))
+        return false;
+    }
+    return true;
+  }
+};
+}  // namespace std
+
+namespace atlas {
+namespace interpreter {
+template <typename T>
+class QueryIndex {
+ public:
+  using QueryPtr = std::shared_ptr<Query>;
+  using RelopQueryPtr = std::shared_ptr<RelopQuery>;
+  using Queries = std::vector<QueryPtr>;
+  using RelopQueries = std::vector<RelopQueryPtr>;
+  using IndexMap =
+      ska::flat_hash_map<RelopQueryPtr, std::shared_ptr<QueryIndex<T>>>;
+  using EntryList = std::vector<QueryIndexEntry<T>>;
+  using AnnotatedList = std::vector<QueryIndexAnnotated<T>>;
+  using AnnotatedIdxMap =
+      ska::flat_hash_map<AnnotatedList, std::shared_ptr<QueryIndex<T>>>;
+
+  QueryIndex(IndexMap indexes, EntryList entries)
+      : indexes_(std::move(indexes)), entries_(std::move(entries)) {}
+
+  static std::shared_ptr<QueryIndex<T>> Create(const EntryList& entries) {
+    std::vector<QueryIndexAnnotated<T>> annotated;
+    annotated.reserve(entries.size() * 2);
+    for (const auto& entry : entries) {
+      Queries to_split = query::dnf_list(entry.query);
+      for (auto& raw_q : to_split) {
+        Queries lst = split(raw_q);
+        for (auto& q : lst) {
+          annotated.emplace_back(annotate(QueryIndexEntry<T>{q, entry.value}));
+        }
+      }
+    }
+    AnnotatedIdxMap idx_map;
+    return create_impl(&idx_map, annotated);
+  }
+
+  static std::shared_ptr<QueryIndex<QueryPtr>> Build(const Queries& queries) {
+    EntryList entries;
+    entries.reserve(queries.size());
+    std::transform(queries.begin(), queries.end(), std::back_inserter(entries),
+                   [](const QueryPtr& q) {
+                     return QueryIndexEntry<QueryPtr>{q, q};
+                   });
+    return QueryIndex<QueryPtr>::Create(entries);
+  }
+
+  bool Matches(const meter::Tags& tags) const noexcept {
+    return !MatchingEntries(tags).empty();
+  }
+
+  std::unordered_set<T> MatchingEntries(const meter::Tags& tags) const
+      noexcept {
+    RelopQueries queries;
+    std::transform(tags.begin(), tags.end(), std::back_inserter(queries),
+                   [](const std::pair<util::StrRef, util::StrRef>& tag) {
+                     return std::make_shared<RelopQuery>(tag.first, tag.second,
+                                                         RelOp::EQ);
+                   });
+    return matching_entries(tags, queries.begin(), queries.end());
+  }
+
+  std::string ToString() const noexcept {
+    std::string res;
+    gen_to_string(&res, 0);
+    return res;
+  }
+
+ protected:
+  IndexMap indexes_;
+  EntryList entries_;
+
+  static std::string query_to_str(const Query& query) {
+    std::ostringstream os;
+    query.Dump(os);
+    return os.str();
+  }
+
+  void gen_to_string(std::string* res, size_t indent) const {
+    std::string pad1(indent, ' ');
+    std::string pad2(indent + 1, ' ');
+
+    std::string& buf = *res;
+    buf += pad1;
+    buf += "children\n";
+    for (const auto& kv : indexes_) {
+      buf += pad2;
+      buf += query_to_str(*kv.first);
+      buf += '\n';
+      kv.second->gen_to_string(res, indent + 2);
+    }
+    buf += pad1;
+    buf += "queries\n";
+    for (const auto& e : entries_) {
+      buf += pad2;
+      buf += query_to_str(*e.query);
+      buf += '\n';
+    }
+  }
+
+  static std::string dump_map(AnnotatedIdxMap* map) {
+    std::ostringstream os;
+    os << "(sz=" << map->size() << ',';
+    for (const auto& kv : *map) {
+      os << dump_anno_entries(kv.first) << ',';
+    }
+    os << ')';
+    return os.str();
+  }
+
+  template <class C>
+  static std::string dump_set(const C& set) {
+    std::ostringstream os;
+    bool first = true;
+    for (const auto& q : set) {
+      if (first) {
+        first = false;
+      } else {
+        os << ',';
+      }
+      q->Dump(os);
+    }
+    return os.str();
+  }
+
+  static std::string dump_anno(const QueryIndexAnnotated<T>& anno) {
+    std::ostringstream os;
+    os << "anno(entry.query=";
+    anno.entry.query->Dump(os);
+    os << ",filters=" << dump_set(anno.filters);
+    os << ')';
+    return os.str();
+  }
+
+  static std::string dump_anno_entries(const AnnotatedList& entries) {
+    std::ostringstream os;
+    os << "(sz=" << entries.size() << ',';
+    bool first = true;
+    for (const auto& anno : entries) {
+      if (first) {
+        first = false;
+      } else {
+        os << ',';
+      }
+      os << dump_anno(anno);
+    }
+    os << ")";
+    return os.str();
+  }
+
+  static std::shared_ptr<QueryIndex<T>> create_impl(
+      AnnotatedIdxMap* idx_map, const AnnotatedList& entries) {
+    const auto& maybe_idx = idx_map->find(entries);
+    if (maybe_idx != idx_map->end()) {
+      return maybe_idx->second;
+    }
+
+    AnnotatedList children;
+    AnnotatedList leaf;
+    std::partition_copy(entries.begin(), entries.end(),
+                        std::back_inserter(children), std::back_inserter(leaf),
+                        [](const QueryIndexAnnotated<T>& entry) {
+                          return !entry.filters.empty();
+                        });
+
+    IndexMap trees;
+
+    ska::flat_hash_map<std::shared_ptr<RelopQuery>, AnnotatedList> grouped_by_q;
+    for (const auto& entry : children) {
+      auto query_anno_list = entry.to_query_annotated_list();
+      for (const auto& query_anno : query_anno_list) {
+        grouped_by_q[query_anno.first].emplace_back(query_anno.second);
+      }
+    }
+
+    for (const auto& q_lst : grouped_by_q) {
+      trees[q_lst.first] = create_impl(idx_map, q_lst.second);
+    }
+
+    EntryList leaf_entries;
+    leaf_entries.reserve(leaf.size());
+    std::transform(leaf.begin(), leaf.end(), std::back_inserter(leaf_entries),
+                   [](const QueryIndexAnnotated<T>& a) { return a.entry; });
+    auto query_index = std::make_shared<QueryIndex>(trees, leaf_entries);
+    idx_map->insert(std::make_pair(entries, query_index));
+    return query_index;
+  }
+
+  std::unordered_set<T> slow_matches(const meter::Tags& tags) const noexcept {
+    std::unordered_set<T> res;
+    for (const auto& e : entries_) {
+      if (e.query->Matches(tags)) {
+        res.emplace(e.value);
+      }
+    }
+    return res;
+  }
+
+  std::unordered_set<T> matching_entries(const meter::Tags& tags,
+                                         RelopQueries::const_iterator begin,
+                                         RelopQueries::const_iterator end) const
+      noexcept {
+    if (begin == end) {
+      return slow_matches(tags);
+    } else {
+      auto& q = *begin;
+      begin++;
+      std::unordered_set<T> children;
+      const auto& matching = indexes_.find(q);
+      if (matching != indexes_.end()) {
+        children = matching->second->matching_entries(tags, begin, end);
+      }
+      append_to_set(&children, slow_matches(tags));
+      append_to_set(&children, matching_entries(tags, begin, end));
+      return children;
+    }
+  }
+
+  // Split :in queries into a list of queries using :eq.
+  static Queries split(QueryPtr q) {
+    Queries result;
+    auto t = q->GetQueryType();
+    if (t == QueryType::And) {
+      auto and_q = std::static_pointer_cast<AndQuery>(q);
+      auto q1 = split(and_q->q1_);
+      auto q2 = split(and_q->q2_);
+      return vector_cross_product(q1, q2, query::and_q);
+    } else if (t == QueryType::In) {
+      auto in_q = std::static_pointer_cast<InQuery>(q);
+      const auto& vs = in_q->Values();
+      // avoid combinatorial explosion with in queries with too many values
+      if (vs.size() < 5) {
+        auto k = in_q->KeyRef();
+        for (auto& v : vs) {
+          result.emplace_back(std::make_shared<RelopQuery>(k, v, RelOp::EQ));
+        }
+      } else {
+        result.emplace_back(q);
+      }
+    } else {
+      result.emplace_back(q);
+    }
+    return result;
+  }
+
+  /// Convert a query into a list of query clauses that are ANDd together.
+  static Queries conjunction_list(const QueryPtr& query) {
+    if (query->GetQueryType() == QueryType::And) {
+      auto and_q = std::static_pointer_cast<AndQuery>(query);
+      return vector_concat(conjunction_list(and_q->q1_),
+                           conjunction_list(and_q->q2_));
+    }
+
+    Queries res;
+    res.emplace_back(query);
+    return res;
+  }
+
+  /// Annotate an entry with a set of :eq queries that should filter in the
+  /// input before checking against the final remaining query. Ideally if the
+  /// query is only using :eq and :and the final remainder will be :true.
+  static QueryIndexAnnotated<T> annotate(const QueryIndexEntry<T>& entry) {
+    auto queries = conjunction_list(entry.query);
+    ska::flat_hash_set<QueryPtr> distinct{queries.begin(), queries.end()};
+    ska::flat_hash_set<std::shared_ptr<RelopQuery>> filters;
+    Queries remainder;
+    for (auto& q : distinct) {
+      if (q->GetQueryType() == QueryType::RelOp) {
+        auto relop = std::static_pointer_cast<RelopQuery>(q);
+        if (relop->GetRelationalOperator() == RelOp::EQ) {
+          filters.emplace(relop);
+        } else {
+          remainder.emplace_back(q);
+        }
+      } else {
+        remainder.emplace_back(q);
+      }
+    }
+    QueryPtr remainder_query =
+        remainder.empty() ? query::true_q() : query::and_queries(remainder);
+    return QueryIndexAnnotated<T>(
+        QueryIndexEntry<T>{remainder_query, entry.value}, std::move(filters));
+  }
+};
+
+}  // namespace interpreter
+}  // namespace atlas

--- a/test/collections_test.cc
+++ b/test/collections_test.cc
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "../util/vector.h"
+#include "../util/collections.h"
 #include <string>
 
 TEST(Vector, Concat) {
@@ -33,3 +33,16 @@ TEST(Vector, Cross) {
   std::vector<std::string> expected{"ac", "ad", "bc", "bd"};
   EXPECT_EQ(res, expected);
 };
+
+TEST(Set, Append_to) {
+  std::unordered_set<int> v1{1, 2, 3};
+  std::unordered_set<int> v2{4, 5, 6};
+  std::unordered_set<int> v3{7, 8, 9};
+
+  std::unordered_set<int> result;
+  append_to_set(&result, std::move(v1));
+  append_to_set(&result, std::move(v2));
+  append_to_set(&result, std::move(v3));
+  std::unordered_set<int> expected{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  EXPECT_EQ(expected, result);
+}

--- a/test/queries_test.cc
+++ b/test/queries_test.cc
@@ -295,7 +295,7 @@ TEST(Queries, DnfSingleQuery) {
   auto dnf = query::dnf_list(q);
   auto expected = Queries{q};
 
-  expect_eq_queries(dnf, expected);
+  EXPECT_EQ_QUERIES(dnf, expected);
 }
 
 TEST(Queries, DnfAnd) {
@@ -303,7 +303,7 @@ TEST(Queries, DnfAnd) {
   auto dnf = query::dnf_list(q);
   auto expected = Queries{q};
 
-  expect_eq_queries(dnf, expected);
+  EXPECT_EQ_QUERIES(dnf, expected);
 }
 
 TEST(Queries, DnfOrAnd) {
@@ -319,7 +319,7 @@ TEST(Queries, DnfOrAnd) {
   QueryPtr ac = query::and_q(a, c);
   QueryPtr bc = query::and_q(b, c);
   auto expected = Queries{ac, bc};
-  expect_eq_queries(dnf, expected);
+  EXPECT_EQ_QUERIES(dnf, expected);
 }
 
 TEST(Queries, DnfOrAndOr) {
@@ -339,7 +339,7 @@ TEST(Queries, DnfOrAndOr) {
   QueryPtr bc = query::and_q(b, c);
   QueryPtr bd = query::and_q(b, d);
   auto expected = Queries{ac, ad, bc, bd};
-  expect_eq_queries(dnf, expected);
+  EXPECT_EQ_QUERIES(dnf, expected);
 }
 
 TEST(Queries, DnfNotOr) {
@@ -355,7 +355,7 @@ TEST(Queries, DnfNotOr) {
   QueryPtr notb = query::not_q(b);
   QueryPtr andq = query::and_q(notb, nota);
   auto expected = Queries{andq};
-  expect_eq_queries(dnf, expected);
+  EXPECT_EQ_QUERIES(dnf, expected);
 }
 
 TEST(Queries, DnfNotAnd) {
@@ -370,5 +370,5 @@ TEST(Queries, DnfNotAnd) {
   QueryPtr nota = query::not_q(a);
   QueryPtr notb = query::not_q(b);
   auto expected = Queries{nota, notb};
-  expect_eq_queries(dnf, expected);
+  EXPECT_EQ_QUERIES(dnf, expected);
 }

--- a/test/query_idx_test.cc
+++ b/test/query_idx_test.cc
@@ -1,0 +1,135 @@
+#include "query_utils.h"
+#include "../interpreter/query_index.h"
+#include "../util/intern.h"
+#include <gtest/gtest.h>
+#include <utility>
+
+using namespace atlas::interpreter;
+using atlas::interpreter::query::and_q;
+using atlas::interpreter::query::eq;
+using atlas::meter::Tags;
+using atlas::util::intern_str;
+
+class QIdx : public QueryIndex<std::shared_ptr<Query>> {
+ public:
+  QIdx(const IndexMap& indexes, const EntryList& entries)
+      : QueryIndex(indexes, entries) {}
+  static Queries split(QueryPtr q) { return QueryIndex::split(std::move(q)); }
+};
+
+TEST(QueryIndex, Split) {
+  auto q = and_q(eq("a", "1"), eq("b", "2"));
+  auto v = std::vector<QIdx::QueryPtr>{q};
+
+  auto split_qs = QIdx::split(q);
+  EXPECT_EQ_QUERIES(v, split_qs);
+}
+
+TEST(QueryIndex, Empty) {
+  QIdx::Queries queries;
+  auto qi = QIdx::Build(queries);
+
+  EXPECT_TRUE(qi->MatchingEntries(Tags{}).empty());
+  EXPECT_TRUE(qi->MatchingEntries(Tags{{"a", "1"}}).empty());
+}
+
+TEST(QueryIndex, SingleQuerySimple) {
+  QIdx::Queries queries;
+  QueryPtr q1 = and_q(eq("a", "1"), eq("b", "2"));
+  queries.emplace_back(q1);
+  auto qi = QIdx::Build(queries);
+
+  std::unordered_set<QueryPtr> expected_matches{q1};
+  // not all tags are present
+  EXPECT_TRUE(qi->MatchingEntries(Tags{}).empty());
+  EXPECT_TRUE(qi->MatchingEntries(Tags{{"a", "1"}}).empty());
+
+  // matches
+  EXPECT_EQ_QUERIES(qi->MatchingEntries(Tags{{"a", "1"}, {"b", "2"}}),
+                    expected_matches);
+  EXPECT_EQ_QUERIES(
+      qi->MatchingEntries(Tags{{"a", "1"}, {"b", "2"}, {"c", "3"}}),
+      expected_matches);
+
+  // a doesn't match
+  EXPECT_TRUE(
+      qi->MatchingEntries(Tags{{"a", "2"}, {"b", "2"}, {"c", "3"}}).empty());
+
+  // b doesn't match
+  EXPECT_TRUE(
+      qi->MatchingEntries(Tags{{"a", "1"}, {"b", "3"}, {"c", "3"}}).empty());
+}
+
+StringRefs genStrRefs(size_t n) {
+  StringRefs res;
+  res.reserve(n);
+  for (auto i = 0u; i < n; ++i) {
+    res.emplace_back(intern_str(std::to_string(i).c_str()));
+  }
+  return res;
+}
+
+TEST(QueryIndex, InExpansionIsLimited) {
+  QueryPtr q1 = query::in("a", genStrRefs(10000));
+  QueryPtr q2 = query::in("b", genStrRefs(10000));
+  QueryPtr q3 = query::in("c", genStrRefs(10000));
+  QueryPtr q = and_q(and_q(q1, q2), q3);
+  Queries qs{q};
+  auto qi = QIdx::Build(qs);
+  EXPECT_TRUE(qi->Matches(Tags{{"a", "1"}, {"b", "9999"}, {"c", "727"}}));
+  EXPECT_FALSE(qi->Matches(Tags{{"a", "1"}, {"b", "10000"}, {"c", "727"}}));
+}
+
+TEST(QueryIndex, ComplexSingleQuery) {
+  QueryPtr q = and_q(and_q(eq("a", "1"), eq("b", "2")), query::has("c"));
+  auto qi = QIdx::Build({Queries{q}});
+
+  EXPECT_FALSE(qi->Matches(Tags{}));
+  EXPECT_FALSE(qi->Matches(Tags{{"a", "1"}}));
+  EXPECT_FALSE(qi->Matches(Tags{{"a", "1"}, {"b", "2"}}));
+  EXPECT_TRUE(qi->Matches(Tags{{"a", "1"}, {"b", "2"}, {"c", "3"}}));
+  EXPECT_FALSE(qi->Matches(Tags{{"a", "2"}, {"b", "2"}, {"c", "3"}}));
+  EXPECT_FALSE(qi->Matches(Tags{{"a", "1"}, {"b", "1"}, {"c", "3"}}));
+}
+
+TEST(QueryIndex, ManyQueries) {
+  QueryPtr cpu_usage = eq("name", "cpuUsage");
+  Queries disk_usage_per_node;
+  disk_usage_per_node.reserve(100);
+  QueryPtr disk_usage = eq("name", "diskUsage");
+  for (auto i = 0; i < 100; ++i) {
+    auto node = fmt::format("i-{:05}", i);
+    disk_usage_per_node.emplace_back(
+        and_q(disk_usage, eq("nf.node", node.c_str())));
+  }
+  Queries queries;
+  queries.reserve(102);
+  queries.push_back(cpu_usage);
+  queries.push_back(disk_usage);
+  append_to_vector(&queries, std::move(disk_usage_per_node));
+  auto qi = QIdx::Build(queries);
+
+  EXPECT_FALSE(qi->Matches(Tags{}));
+  EXPECT_FALSE(qi->Matches(Tags{{"a", "1"}}));
+
+  std::unordered_set<QueryPtr> cpu_usage_set{cpu_usage};
+  EXPECT_EQ_QUERIES(
+      qi->MatchingEntries(Tags{{"name", "cpuUsage"}, {"nf.node", "unknown"}}),
+      cpu_usage_set);
+  EXPECT_EQ_QUERIES(
+      qi->MatchingEntries(Tags{{"name", "cpuUsage"}, {"nf.node", "i-00099"}}),
+      cpu_usage_set);
+
+  std::unordered_set<QueryPtr> expected_disk1{
+      disk_usage, and_q(disk_usage, eq("nf.node", "i-00099"))};
+  EXPECT_EQ_QUERIES(
+      qi->MatchingEntries(Tags{{"name", "diskUsage"}, {"nf.node", "i-00099"}}),
+      expected_disk1);
+
+  std::unordered_set<QueryPtr> expected_disk2{disk_usage};
+  EXPECT_EQ_QUERIES(
+      qi->MatchingEntries(Tags{{"name", "diskUsage"}, {"nf.node", "unknown"}}),
+      expected_disk2);
+
+  EXPECT_FALSE(qi->Matches(Tags{{"nf.node", "unknown"}}));
+}

--- a/test/query_utils.h
+++ b/test/query_utils.h
@@ -10,7 +10,8 @@ using atlas::interpreter::QueryType;
 using QueryPtr = std::shared_ptr<Query>;
 using Queries = std::vector<QueryPtr>;
 
-inline std::string queries_to_str(const Queries& qs) {
+template <typename T>
+inline std::string queries_to_str(const T& qs) {
   std::ostringstream os;
   os << '[';
   auto first = true;
@@ -32,10 +33,11 @@ inline std::string query_to_str(const Query& q) {
   return os.str();
 }
 
-inline void expect_eq_queries(Queries& lhs, Queries& rhs) {
+inline void expect_eq_queries(const char* file, int line, const Queries& lhs,
+                              const Queries& rhs) {
   if (lhs.size() != rhs.size()) {
-    FAIL() << "lhs.size()=" << lhs.size() << " != rhs.size()=" << rhs.size()
-           << "\n"
+    FAIL() << file << ":" << line << ": lhs.size()=" << lhs.size()
+           << " != rhs.size()=" << rhs.size() << "\n"
            << queries_to_str(lhs) << " != " << queries_to_str(rhs);
   }
 
@@ -49,3 +51,24 @@ inline void expect_eq_queries(Queries& lhs, Queries& rhs) {
     }
   }
 }
+
+inline void expect_eq_queries(const char* file, int line,
+                              const std::unordered_set<QueryPtr>& lhs,
+                              const std::unordered_set<QueryPtr>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    std::cerr << fmt::format("{}:{} lhs.size()={} != rhs.size()={}\n", file,
+                             line, lhs.size(), rhs.size());
+    GTEST_FAIL();
+  }
+
+  for (const auto& q1 : lhs) {
+    auto found = rhs.find(q1) != rhs.end();
+    if (!found) {
+      std::cerr << fmt::format("{}:{} {} not found in {}\n", file, line,
+                               query_to_str(*q1), queries_to_str(rhs));
+      GTEST_FAIL();
+    }
+  }
+}
+
+#define EXPECT_EQ_QUERIES(a, b) expect_eq_queries(__FILE__, __LINE__, a, b)

--- a/util/collections.h
+++ b/util/collections.h
@@ -1,5 +1,15 @@
 #pragma once
 #include <vector>
+#include <unordered_set>
+
+template <typename T>
+void append_to_set(std::unordered_set<T>* dest,
+                   std::unordered_set<T>&& to_append) {
+  dest->reserve(dest->size() + to_append.size());
+  for (auto&& item : to_append) {
+    dest->emplace(std::move(item));
+  }
+}
 
 template <typename T>
 void append_to_vector(std::vector<T>* dest, std::vector<T>&& to_append) {


### PR DESCRIPTION
Add a query index to help evaluating thousands of queries. We'll need to
evaluate the resource utilization and optimize it in a subsequent PR, as
well as integrate it in the subscription manager if we can get the overhead to a reasonable level.