### PR TITLE
Advance the clock at shutdown 1-step

### DIFF
--- a/meter/subscription_manager.cc
+++ b/meter/subscription_manager.cc
@@ -268,7 +268,7 @@ void SubscriptionManager::Stop() noexcept {
 
     flush_metrics();
     Logger()->info("Advancing clock and flushing metrics");
-    clock_->SetOffset(4990);
+    clock_->SetOffset(59990);
     flush_metrics();
   }
 }

--- a/meter/subscription_manager.cc
+++ b/meter/subscription_manager.cc
@@ -266,9 +266,13 @@ void SubscriptionManager::Stop() noexcept {
     Logger()->debug("Stopping sub_refresher");
     sub_refresher_thread.join();
 
+    // this is the timestamp that will be used when flushing metrics
+    auto prev_step = clock_->WallTime() / kMainFrequencyMillis * kMainFrequencyMillis;
     flush_metrics();
+    // move the clock forward to send partial increments for step counters
+    auto now_offset = clock_->WallTime() - prev_step;
     Logger()->info("Advancing clock and flushing metrics");
-    clock_->SetOffset(59990);
+    clock_->SetOffset(kMainFrequencyMillis - now_offset);
     flush_metrics();
   }
 }


### PR DESCRIPTION
To avoid sending metrics with duplicated timestamps advance the clock
to the next step for the main publishing pipeline