### PR TITLE
Use step numbers for the consolidated registry

### DIFF
--- a/meter/consolidation_registry.h
+++ b/meter/consolidation_registry.h
@@ -3,20 +3,59 @@
 #include <mutex>
 #include <ska/flat_hash_map.hpp>
 #include "registry.h"
+#include "stepnumber.h"
 namespace atlas {
 
 namespace meter {
 
-class ConsolidationRegistry {
+class ConsolidatedValue {
  public:
-  ConsolidationRegistry(int64_t update_frequency,
-                        int64_t reporting_frequency) noexcept;
-  void update_from(const Measurements& measurements) noexcept;
-  Measurements measurements() const noexcept;
+  static constexpr auto kMinValue = std::numeric_limits<double>::lowest();
+  ConsolidatedValue(bool is_gauge, int update_multiple, int64_t step_ms,
+                    const Clock* clock)
+      : is_gauge_(is_gauge),
+        update_multiple_(update_multiple),
+        v(StepNumber<double>(is_gauge ? kMinValue : 0.0, step_ms, clock)),
+        marked_{false} {}
+  bool has_value() const {
+    auto value = v.Poll();
+    return is_gauge_ ? value > kMinValue : value > 0;
+  }
+  double value() const { return v.Poll(); }
+  void update(double value) {
+    if (is_gauge_) {
+      v.UpdateCurrentMax(value);
+    } else {
+      v.Add(value / update_multiple_);
+    }
+  }
+  bool marked() const noexcept { return marked_; }
+  void set_marked(bool marked) noexcept { marked_ = marked; }
 
  private:
+  bool is_gauge_;
+  int update_multiple_;
+  StepNumber<double> v;
+  bool marked_;
+};
+
+class ConsolidationRegistry {
+ public:
+  ConsolidationRegistry(int64_t update_frequency, int64_t reporting_frequency,
+                        const Clock* clock) noexcept;
+  void update_from(const Measurements& measurements) noexcept;
+  Measurements measurements(int64_t timestamp) const noexcept;
+  size_t size() const noexcept {
+    std::lock_guard<std::mutex> guard{mutex};
+    return my_values.size();
+  }
+
+ private:
+  int64_t reporting_frequency_;
   int64_t update_multiple;
-  mutable ska::flat_hash_map<IdPtr, Measurement> my_measures;
+  const Clock* clock_;
+  using values_map = ska::flat_hash_map<IdPtr, ConsolidatedValue>;
+  mutable values_map my_values;
   mutable std::mutex mutex;
 };
 

--- a/meter/default_counter.h
+++ b/meter/default_counter.h
@@ -17,7 +17,7 @@ class DefaultCounterNumber : public Meter, public CounterNumber<T> {
  public:
   DefaultCounterNumber(IdPtr id, const Clock& clock, int64_t freq_millis)
       : Meter(WithDefaultTagForId(id, statistic::count), clock),
-        step_number_(0, freq_millis, clock),
+        step_number_(0, freq_millis, &clock),
         value_(0) {
     Updated();
   }

--- a/meter/default_max_gauge.h
+++ b/meter/default_max_gauge.h
@@ -17,7 +17,7 @@ class DefaultMaxGauge : public Meter, public Gauge<T> {
   DefaultMaxGauge(IdPtr id, const Clock& clock, int64_t freq_millis)
       : Meter(WithDefaultGaugeTags(std::move(id), statistic::max), clock),
         value_(0),
-        step_number_(kMinValue, freq_millis, clock) {
+        step_number_(kMinValue, freq_millis, &clock) {
     Updated();
   }
 

--- a/test/cons_registry_test.cc
+++ b/test/cons_registry_test.cc
@@ -1,23 +1,33 @@
 #include "../meter/consolidation_registry.h"
+#include "../meter/manual_clock.h"
 #include "../util/config.h"
 #include "test_utils.h"
 #include <gtest/gtest.h>
 
 using atlas::meter::ConsolidationRegistry;
 using atlas::meter::Id;
+using atlas::meter::ManualClock;
 using atlas::meter::Measurement;
 using atlas::meter::Measurements;
 using atlas::meter::Tags;
 using atlas::util::kFastestFrequencyMillis;
 using atlas::util::kMainFrequencyMillis;
 
+static void update_timestamp(Measurements* measurements, int64_t ts) {
+  for (auto& m : *measurements) {
+    m.timestamp = ts;
+  }
+}
+
 TEST(ConsolidationRegistry, Empty) {
-  ConsolidationRegistry registry{kFastestFrequencyMillis, kMainFrequencyMillis};
-  auto ms = registry.measurements();
+  ManualClock clock;
+  ConsolidationRegistry registry{kFastestFrequencyMillis, kMainFrequencyMillis,
+                                 &clock};
+  auto ms = registry.measurements(clock.WallTime());
   ASSERT_TRUE(ms.empty());
 
   registry.update_from(Measurements{});
-  ASSERT_TRUE(registry.measurements().empty());
+  ASSERT_TRUE(registry.measurements(clock.WallTime()).empty());
 }
 
 bool operator==(const atlas::meter::Measurement& a,
@@ -27,7 +37,10 @@ bool operator==(const atlas::meter::Measurement& a,
 }
 
 TEST(ConsolidationRegistry, UpdateOne) {
-  ConsolidationRegistry registry{kFastestFrequencyMillis, kMainFrequencyMillis};
+  ManualClock clock;
+  ConsolidationRegistry registry{kFastestFrequencyMillis, kMainFrequencyMillis,
+                                 &clock};
+  clock.SetWall(1000);
 
   auto gauge_id = std::make_shared<Id>("gauge", Tags{{"statistic", "gauge"}});
   auto random_id = std::make_shared<Id>("random", Tags{});
@@ -41,52 +54,57 @@ TEST(ConsolidationRegistry, UpdateOne) {
   auto measurements = Measurements{gauge, random, counter};
 
   registry.update_from(measurements);
-  auto ms = registry.measurements();
+  clock.SetWall(60000);
+  auto ms = registry.measurements(clock.WallTime());
   auto measure_cmp = [](const Measurement& a, const Measurement& b) {
     return *(a.id) < *(b.id);
   };
 
   // 60s for measurements
-  auto counter_minute = Measurement{counter_id, 1L, 1 / 60.0};
+  auto counter_minute = Measurement{counter_id, clock.WallTime(), 1 / 60.0};
   auto expected_measurements = Measurements{gauge, random, counter_minute};
+  update_timestamp(&expected_measurements, clock.WallTime());
   std::sort(expected_measurements.begin(), expected_measurements.end(),
             measure_cmp);
   std::sort(ms.begin(), ms.end(), measure_cmp);
 
   EXPECT_EQ(ms, expected_measurements);
-  EXPECT_TRUE(registry.measurements().empty()) << "Resets after being measured";
-}
-
-static void update_timestamp(Measurements* measurements, int64_t ts) {
-  for (auto& m : *measurements) {
-    m.timestamp = ts;
-  }
 }
 
 TEST(ConsolidationRegistry, Consolidate) {
-  ConsolidationRegistry registry{kFastestFrequencyMillis, kMainFrequencyMillis};
+  ManualClock clock;
+  ConsolidationRegistry registry{kFastestFrequencyMillis, kMainFrequencyMillis,
+                                 &clock};
 
   auto gauge_id = std::make_shared<Id>("gauge", Tags{{"statistic", "gauge"}});
   auto random_id = std::make_shared<Id>("random", Tags{});
   auto counter_id =
       std::make_shared<Id>("counter", Tags{{"statistic", "count"}});
 
-  auto gauge = Measurement{gauge_id, 1L, 1.0};
-  auto random = Measurement{random_id, 1L, 42.0};
-  auto counter = Measurement{counter_id, 1L, 1 / 5.0};
+  clock.SetWall(1000);
+  auto gauge = Measurement{gauge_id, clock.WallTime(), 1.0};
+  auto random = Measurement{random_id, clock.WallTime(), 42.0};
+  auto counter = Measurement{counter_id, clock.WallTime(), 1 / 5.0};
   auto measurements = Measurements{gauge, random, counter};
 
   registry.update_from(measurements);
 
-  update_timestamp(&measurements, 2L);
+  clock.SetWall(6000);
+  update_timestamp(&measurements, clock.WallTime());
   registry.update_from(measurements);
 
   for (auto& m : measurements) {
     m.value += 1 / 5.0;
   }
-  update_timestamp(&measurements, 3L);
+  clock.SetWall(11000);
+  update_timestamp(&measurements, clock.WallTime());
   registry.update_from(measurements);
-  auto ms = registry.measurements();
+
+  clock.SetWall(51000);
+  update_timestamp(&measurements, clock.WallTime());
+  registry.update_from(measurements);
+  clock.SetWall(61000);
+  auto ms = registry.measurements(clock.WallTime());
   auto measure_cmp = [](const Measurement& a, const Measurement& b) {
     return *(a.id) < *(b.id);
   };
@@ -94,26 +112,39 @@ TEST(ConsolidationRegistry, Consolidate) {
 
   ASSERT_EQ(ms.size(), 3);
   EXPECT_EQ(ms[0].id, counter.id);
-  EXPECT_EQ(ms[0].value, 4.0 / 60);  // (0.2, 0.2, 0.4 => deltas = 1, 1, 2)
+  EXPECT_EQ(ms[0].value,
+            6.0 / 60);  // (0.2, 0.2, 0.4, 0.4 => deltas = 1, 1, 2, 2)
   EXPECT_EQ(ms[1].id, gauge.id);
   EXPECT_EQ(ms[1].value, 1.2);  // max
   EXPECT_EQ(ms[2].id, random.id);
   EXPECT_EQ(ms[2].value, 42.2);  // max
 }
 
-TEST(ConsolidationRegistry, IgnoreDupes) {
-  ConsolidationRegistry registry{kFastestFrequencyMillis, kMainFrequencyMillis};
+TEST(ConsolidationRegistry, Expiration) {
+  ManualClock clock;
+  clock.SetWall(1000);
+  ConsolidationRegistry registry{kFastestFrequencyMillis, kMainFrequencyMillis,
+                                 &clock};
 
+  auto gauge_id = std::make_shared<Id>("gauge", Tags{{"statistic", "gauge"}});
   auto counter_id =
       std::make_shared<Id>("counter", Tags{{"statistic", "count"}});
+  auto gauge = Measurement{gauge_id, clock.WallTime(), 1.0};
+  auto counter = Measurement{counter_id, clock.WallTime(), 1 / 5.0};
+  auto measurements = Measurements{counter, gauge};
 
-  auto counter = Measurement{counter_id, 1L, 1 / 5.0};
-  auto measurements = Measurements{counter};
+  registry.update_from(measurements);
+  clock.SetWall(61000);
+  auto ms = registry.measurements(clock.WallTime());
+  EXPECT_EQ(registry.size(), 2);
 
-  registry.update_from(measurements);
-  registry.update_from(measurements);
-  registry.update_from(measurements);
-  auto ms = registry.measurements();
-  ASSERT_EQ(ms.size(), 1);
-  EXPECT_EQ(ms[0].value, 1.0 / 60);
+  clock.SetWall(121000);
+  ms = registry.measurements(clock.WallTime());
+  EXPECT_TRUE(ms.empty());  // no data
+  EXPECT_EQ(registry.size(), 2);
+
+  clock.SetWall(181000);
+  ms = registry.measurements(clock.WallTime());
+  EXPECT_TRUE(ms.empty());  // no data
+  EXPECT_EQ(registry.size(), 0);
 }

--- a/test/steplong_test.cc
+++ b/test/steplong_test.cc
@@ -3,35 +3,36 @@
 #include <gtest/gtest.h>
 
 using namespace ::atlas::meter;
-static ManualClock manual_clock;
 
 TEST(StepLong, Init) {
-  StepLong s(0, 10, manual_clock);
+  ManualClock manual_clock;
+  StepLong s(0, 10, &manual_clock);
   EXPECT_EQ(0, s.Current());
   EXPECT_EQ(0, s.Poll());
 }
 
 TEST(StepLong, Increment) {
-  StepLong s(0, 10, manual_clock);
+  ManualClock manual_clock;
+  StepLong s(0, 10, &manual_clock);
   s.Add(1);
   EXPECT_EQ(1, s.Current());
   EXPECT_EQ(0, s.Poll());
 }
 
 TEST(StepLong, IncrementAndCrossStep) {
-  StepLong s(0, 10, manual_clock);
+  ManualClock manual_clock;
+  StepLong s(0, 10, &manual_clock);
   s.Add(1);
   manual_clock.SetWall(10);
   EXPECT_EQ(0, s.Current());
   EXPECT_EQ(1, s.Poll());
-  manual_clock.SetWall(0);
 }
 
 TEST(StepLong, MissedRead) {
-  StepLong s(0, 10, manual_clock);
+  ManualClock manual_clock;
+  StepLong s(0, 10, &manual_clock);
   s.Add(1);
   manual_clock.SetWall(20);
   EXPECT_EQ(0, s.Current());
   EXPECT_EQ(0, s.Poll());
-  manual_clock.SetWall(0);
 }


### PR DESCRIPTION
We need to honor the timestamps and use step numbers to properly
attribute updates to a given interval. This also means we can't just
clear the registry after taken the measurements since the step numbers
can have partial updates for the next step, so we need a way to properly
expire them.