### PR TITLE
Use the beginning of the step for updates

### DIFF
--- a/atlas_client.cc
+++ b/atlas_client.cc
@@ -8,7 +8,7 @@
 
 using atlas::meter::Registry;
 using atlas::meter::SubscriptionManager;
-using atlas::meter::SystemClockWithOffset;
+using atlas::meter::WrappedClock;
 using atlas::util::ConfigManager;
 using atlas::util::http;
 using atlas::util::Logger;
@@ -32,6 +32,7 @@ class Client::impl {
  public:
   impl()
       : started{false},
+        clock{&system_clock},
         config_manager{util::kLocalFileName, util::kConfigRefreshMillis},
         subscription_manager{&clock, config_manager} {}
 
@@ -105,7 +106,8 @@ class Client::impl {
 
  private:
   bool started;
-  SystemClockWithOffset clock;
+  atlas::meter::SystemClock system_clock;
+  WrappedClock clock;
   ConfigManager config_manager;
   SubscriptionManager subscription_manager;
 };

--- a/meter/clock.h
+++ b/meter/clock.h
@@ -21,23 +21,20 @@ class SystemClock : public Clock {
   int64_t MonotonicTime() const noexcept override;
 };
 
-class SystemClockWithOffset : public Clock {
+class WrappedClock : public Clock {
  public:
-  SystemClockWithOffset() noexcept : offset_{0} {}
-
+  explicit WrappedClock(const Clock* clock) : underlying_(clock) {}
+  void SetOffset(int offset) { offset_ = offset; }
   int64_t WallTime() const noexcept override {
-    return clock.WallTime() + offset_;
+    return underlying_->WallTime() + offset_;
   }
-
   int64_t MonotonicTime() const noexcept override {
-    return clock.MonotonicTime();
+    return underlying_->MonotonicTime() + offset_ * 1000000;
   }
-
-  void SetOffset(int64_t offset) noexcept { offset_ = offset; }
 
  private:
-  SystemClock clock;
-  int64_t offset_;
+  const Clock* underlying_;
+  int offset_ = 0;
 };
 
 }  // namespace meter

--- a/meter/consolidation_registry.cc
+++ b/meter/consolidation_registry.cc
@@ -41,6 +41,9 @@ void ConsolidationRegistry::update_from(
   std::lock_guard<std::mutex> guard{mutex};
 
   auto update_multiple = reporting_frequency_ / update_frequency_;
+  // set the clock to the beginning of the updating frequency step
+  // this allows us to attribute the update to the correct time period
+  // when we update the StepNumber for the reporting frequency step
   clock_.SetOffset(-update_frequency_);
   for (const auto& m : measurements) {
     if (std::isnan(m.value)) {
@@ -59,6 +62,8 @@ void ConsolidationRegistry::update_from(
     auto& my_value = it->second;
     my_value.update(m.value);
   }
+  // reset the clock to the correct time, so measurements are taken using a full reporting
+  // frequency step
   clock_.SetOffset(0);
 }
 

--- a/meter/consolidation_registry.h
+++ b/meter/consolidation_registry.h
@@ -51,9 +51,9 @@ class ConsolidationRegistry {
   }
 
  private:
+  int64_t update_frequency_;
   int64_t reporting_frequency_;
-  int64_t update_multiple;
-  const Clock* clock_;
+  WrappedClock clock_;
   using values_map = ska::flat_hash_map<IdPtr, ConsolidatedValue>;
   mutable values_map my_values;
   mutable std::mutex mutex;

--- a/meter/subscription_manager.h
+++ b/meter/subscription_manager.h
@@ -17,7 +17,7 @@ using ParsedSubscriptions = std::array<Subscriptions, util::kMainMultiple>;
 
 class SubscriptionManager {
  public:
-  SubscriptionManager(SystemClockWithOffset* clock,
+  SubscriptionManager(WrappedClock* clock,
                       const util::ConfigManager& config_manager) noexcept;
   ~SubscriptionManager();
 
@@ -35,7 +35,7 @@ class SubscriptionManager {
   std::shared_ptr<Registry> GetRegistry() { return registry_; }
 
  private:
-  SystemClockWithOffset* clock_;
+  WrappedClock* clock_;
   interpreter::Evaluator evaluator_;
   const util::ConfigManager& config_manager_;
   std::shared_ptr<Registry> registry_;  // 5s registry

--- a/test/atlas_registry_test.cc
+++ b/test/atlas_registry_test.cc
@@ -19,7 +19,7 @@ using namespace atlas::meter;
 
 TEST(AtlasRegistry, MetersExpire) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   r.SetWall(42);
   Tags tags{{"k1", "v1"}, {"k2", "v2"}};
   auto id1 = r.CreateId("m1", tags);
@@ -48,7 +48,7 @@ TEST(AtlasRegistry, MetersExpire) {
 
 TEST(AtlasRegistry, MeasurementsExpire) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   r.SetWall(42);
   Tags tags{{"k1", "v1"}, {"k2", "v2"}};
   auto id1 = r.CreateId("m1", tags);
@@ -73,7 +73,7 @@ TEST(AtlasRegistry, MeasurementsExpire) {
 
 TEST(AtlasRegistry, DiffTypes) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
 
   auto id = r.CreateId("foo", {{"statistic", "test"}});
   r.timer(id)->Record(21);

--- a/test/bucket_counter_test.cc
+++ b/test/bucket_counter_test.cc
@@ -17,7 +17,7 @@ using std::chrono::microseconds;
 
 TEST(BucketCounter, Init) {
   ManualClock m;
-  TestRegistry r{&m};
+  TestRegistry r{60000, &m};
   auto id = r.CreateId("test", kEmptyTags);
   BucketCounter b(&r, id, Age(microseconds{100}));
   auto ms = r.measurements_for_name("test");
@@ -28,7 +28,7 @@ TEST(BucketCounter, Init) {
 static constexpr int64_t kMicrosToNanos = 1000l;
 TEST(BucketCounter, Record) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   r.SetWall(1000);
 
   auto id = r.CreateId("test", kEmptyTags);

--- a/test/bucket_dist_summary_test.cc
+++ b/test/bucket_dist_summary_test.cc
@@ -15,7 +15,7 @@ using std::chrono::seconds;
 
 TEST(BucketDistributionSummary, Init) {
   ManualClock m;
-  TestRegistry r{&m};
+  TestRegistry r{60000, &m};
 
   auto id = r.CreateId("test", kEmptyTags);
   BucketDistributionSummary ds(&r, id, Age(seconds{60}));
@@ -28,7 +28,7 @@ static constexpr int64_t kSecsToNanos = 1000l * 1000l * 1000l;
 
 TEST(BucketDistributionSummary, Record) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   r.SetWall(1000);
 
   auto id = r.CreateId("test", kEmptyTags);

--- a/test/bucket_timer_test.cc
+++ b/test/bucket_timer_test.cc
@@ -17,7 +17,7 @@ using std::chrono::seconds;
 
 TEST(BucketTimer, Init) {
   ManualClock m;
-  TestRegistry r{&m};
+  TestRegistry r{60000, &m};
 
   auto id = r.CreateId("test", kEmptyTags);
   BucketTimer t(&r, id, Age(milliseconds{100}));
@@ -29,7 +29,7 @@ static constexpr auto kMillisToSecs = 1 / 1000.0;
 
 TEST(BucketTimer, Record) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   r.SetWall(1000);
 
   auto id = r.CreateId("test", kEmptyTags);
@@ -66,7 +66,7 @@ TEST(BucketTimer, Record) {
 
 TEST(BucketTimer, Latency) {
   ManualClock m;
-  TestRegistry r{&m};
+  TestRegistry r{60000, &m};
   r.SetWall(1000);
 
   auto id = r.CreateId("bucket.t", kEmptyTags);

--- a/test/default_counter_test.cc
+++ b/test/default_counter_test.cc
@@ -65,7 +65,7 @@ TEST(DefaultCounterTest, Measure) {
 
 TEST(DefaultCounter, Expiration) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
 
   auto id = r.CreateId("test", kEmptyTags);
   r.counter(id)->Increment();

--- a/test/default_dist_summary_test.cc
+++ b/test/default_dist_summary_test.cc
@@ -8,7 +8,7 @@ using namespace atlas::meter;
 using atlas::util::kMainFrequencyMillis;
 
 static ManualClock manual_clock;
-static TestRegistry test_registry{&manual_clock};
+static TestRegistry test_registry{60000, &manual_clock};
 static auto id = test_registry.CreateId("foo", kEmptyTags);
 
 static std::unique_ptr<DefaultDistributionSummary> newDistSummary() {
@@ -81,7 +81,7 @@ TEST(DefaultDistSummary, Measure) {
 
 TEST(DefaultDistSummary, Expiration) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
 
   auto id = r.CreateId("test", kEmptyTags);
   r.distribution_summary(id)->Record(1);

--- a/test/default_timer_test.cc
+++ b/test/default_timer_test.cc
@@ -83,7 +83,7 @@ TEST(DefaultTimer, Measure) {
 
 TEST(DefaultTimer, Expiration) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
 
   auto id = r.CreateId("test", kEmptyTags);
   r.timer(id)->Record(1);

--- a/test/http_test.cc
+++ b/test/http_test.cc
@@ -54,7 +54,7 @@ TEST(HttpTest, Post) {
 
   auto cfg = HttpConfig();
   ManualClock clock;
-  auto registry = std::make_shared<TestRegistry>(&clock);
+  auto registry = std::make_shared<TestRegistry>(60000, &clock);
   http client{registry, cfg};
   auto url = fmt::format("http://localhost:{}/foo", port);
   const std::string post_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -131,7 +131,7 @@ TEST(HttpTest, PostBatches) {
 
   auto cfg = HttpConfig();
   ManualClock clock;
-  auto registry = std::make_shared<TestRegistry>(&clock);
+  auto registry = std::make_shared<TestRegistry>(60000, &clock);
   http client{registry, cfg};
 
   auto url = fmt::format("http://localhost:{}/foo", port);
@@ -185,7 +185,7 @@ TEST(HttpTest, Timeout) {
   cfg.connect_timeout = 1;
   cfg.read_timeout = 1;
   ManualClock clock;
-  auto registry = std::make_shared<TestRegistry>(&clock);
+  auto registry = std::make_shared<TestRegistry>(60000, &clock);
   http client{registry, cfg};
   auto url = fmt::format("http://localhost:{}/foo", port);
   const std::string post_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -217,7 +217,7 @@ TEST(HttpTest, ConditionalGet) {
   auto cfg = HttpConfig();
   cfg.read_timeout = 60;
   ManualClock clock;
-  auto registry = std::make_shared<TestRegistry>(&clock);
+  auto registry = std::make_shared<TestRegistry>(60000, &clock);
   http client{registry, cfg};
   auto url = fmt::format("http://localhost:{}/get", port);
 
@@ -287,7 +287,7 @@ TEST(HttpTest, CompressedGet) {
   auto cfg = HttpConfig();
   cfg.read_timeout = 60;
   ManualClock manual_clock;
-  auto registry = std::make_shared<TestRegistry>(&manual_clock);
+  auto registry = std::make_shared<TestRegistry>(60000, &manual_clock);
   http client{registry, cfg};
 
   auto url = fmt::format("http://localhost:{}/compressed", port);

--- a/test/interval_counter_test.cc
+++ b/test/interval_counter_test.cc
@@ -13,7 +13,7 @@ using atlas::util::intern_str;
 
 TEST(IntervalCounter, Init) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   r.SetWall(42 * 1000);
   auto id = r.CreateId("test", kEmptyTags);
   IntervalCounter c{&r, id};
@@ -24,7 +24,7 @@ TEST(IntervalCounter, Init) {
 
 TEST(IntervalCounter, Interval) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   r.SetWall(0);
   auto id = r.CreateId("test", kEmptyTags);
   IntervalCounter c{&r, id};
@@ -41,7 +41,7 @@ TEST(IntervalCounter, Interval) {
 
 TEST(IntervalCounter, Increment) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   auto id = r.CreateId("test", kEmptyTags);
   IntervalCounter c{&r, id};
 
@@ -70,7 +70,7 @@ void assert_interval_counter(const Measurements& ms, int64_t timestamp,
 
 TEST(IntervalCounter, Measure) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   auto id = r.CreateId("test", kEmptyTags);
   IntervalCounter c{&r, id};
 
@@ -91,7 +91,7 @@ TEST(IntervalCounter, Measure) {
 
 TEST(IntervalCounter, ReusesInstance) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
 
   auto id = r.CreateId("test", kEmptyTags);
 
@@ -109,7 +109,7 @@ TEST(IntervalCounter, ReusesInstance) {
 TEST(IntervalCounter, Expiration) {
   // make sure we always report the interval since last update
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
 
   auto id = r.CreateId("test", kEmptyTags);
   IntervalCounter c{&r, id};

--- a/test/monotonic_counter_test.cc
+++ b/test/monotonic_counter_test.cc
@@ -6,14 +6,14 @@ using namespace atlas::meter;
 
 TEST(MonotonicCounter, Init) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   MonotonicCounter counter{&r, r.CreateId("ctr", kEmptyTags)};
   EXPECT_EQ(0, counter.Count()) << "A new counter should report a value of 0";
 }
 
 TEST(MonotonicCounter, Set) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   MonotonicCounter counter{&r, r.CreateId("ctr", kEmptyTags)};
   counter.Set(100);
 
@@ -25,7 +25,7 @@ TEST(MonotonicCounter, Set) {
 
 TEST(MonotonicCounter, NotEnoughData) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   MonotonicCounter counter{&r, r.CreateId("ctr", kEmptyTags)};
 
   EXPECT_EQ(0, r.measurements_for_name("ctr").size())
@@ -47,7 +47,7 @@ TEST(MonotonicCounter, NotEnoughData) {
 
 TEST(MonotonicCounter, Rate) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   MonotonicCounter counter{&r, r.CreateId("ctr", kEmptyTags)};
 
   r.SetWall(1000);
@@ -66,7 +66,7 @@ TEST(MonotonicCounter, Rate) {
 
 TEST(MonotonicCounter, Expiration) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   MonotonicCounter counter{&r, r.CreateId("ctr", kEmptyTags)};
 
   r.SetWall(61000);
@@ -86,7 +86,7 @@ TEST(MonotonicCounter, Expiration) {
 
 TEST(MonotonicCounter, Overflow) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   MonotonicCounter counter{&r, r.CreateId("ctr", kEmptyTags)};
 
   r.SetWall(1000);

--- a/test/percentile_dist_summary_test.cc
+++ b/test/percentile_dist_summary_test.cc
@@ -9,7 +9,7 @@ using atlas::util::intern_str;
 
 TEST(PercentileDistributionSummary, Percentile) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   PercentileDistributionSummary d{&r, r.CreateId("foo", kEmptyTags)};
 
   for (auto i = 0; i < 100000; ++i) {
@@ -25,7 +25,7 @@ TEST(PercentileDistributionSummary, Percentile) {
 
 TEST(PercentileDistributionSummary, HasProperStatistic) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   PercentileDistributionSummary t{&r, r.CreateId("foo", kEmptyTags)};
   t.Record(42);
 
@@ -42,7 +42,7 @@ TEST(PercentileDistributionSummary, HasProperStatistic) {
 
 TEST(PercentileDistributionSummary, CountTotal) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   PercentileDistributionSummary d{&r, r.CreateId("foo", kEmptyTags)};
 
   for (auto i = 0; i < 100; ++i) {

--- a/test/percentile_timer_test.cc
+++ b/test/percentile_timer_test.cc
@@ -7,7 +7,7 @@ using atlas::util::intern_str;
 
 TEST(PercentileTimer, Percentile) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   PercentileTimer t{&r, r.CreateId("foo", kEmptyTags)};
 
   for (auto i = 0; i < 100000; ++i) {
@@ -23,7 +23,7 @@ TEST(PercentileTimer, Percentile) {
 
 TEST(PercentileTimer, HasProperStatistic) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   PercentileTimer t{&r, r.CreateId("foo", kEmptyTags)};
 
   t.Record(std::chrono::milliseconds{42});
@@ -41,7 +41,7 @@ TEST(PercentileTimer, HasProperStatistic) {
 
 TEST(PercentileTimer, CountTotal) {
   ManualClock manual_clock;
-  TestRegistry r{&manual_clock};
+  TestRegistry r{60000, &manual_clock};
   PercentileTimer t{&r, r.CreateId("foo", kEmptyTags)};
 
   for (auto i = 0; i < 100; ++i) {

--- a/test/system_clock_test.cc
+++ b/test/system_clock_test.cc
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 
 using atlas::meter::SystemClock;
-using atlas::meter::SystemClockWithOffset;
+using atlas::meter::WrappedClock;
 
 TEST(SystemClock, WallTime) {
   SystemClock clock;
@@ -14,8 +14,9 @@ TEST(SystemClock, WallTime) {
   EXPECT_LE(std::abs(secs - clock_secs), 1);
 }
 
-TEST(SystemClockOffset, WallTimeOffset) {
-  SystemClockWithOffset clock;
+TEST(WrappedClock, WallTimeOffset) {
+  SystemClock sys_clock;
+  WrappedClock clock{&sys_clock};
 
   clock.SetOffset(5000);
   auto clock_now = clock.WallTime();
@@ -26,8 +27,8 @@ TEST(SystemClockOffset, WallTimeOffset) {
   EXPECT_TRUE(delta >= 5 && delta <= 6);
 }
 
-TEST(SystemClockWithOffset, MonotonicTime) {
-  SystemClockWithOffset clock;
+TEST(SystemClock, MonotonicTime) {
+  SystemClock clock;
   for (auto j = 0; j < 10; ++j) {
     auto prev = clock.MonotonicTime();
     for (auto i = 0; i < 100; ++i) {

--- a/test/test_registry.h
+++ b/test/test_registry.h
@@ -5,8 +5,9 @@
 
 class TestRegistry : public atlas::meter::AtlasRegistry {
  public:
-  TestRegistry(const atlas::meter::ManualClock* manual_clock)
-      : atlas::meter::AtlasRegistry(60000, manual_clock),
+  TestRegistry(int64_t step_millis,
+               const atlas::meter::ManualClock* manual_clock)
+      : atlas::meter::AtlasRegistry(step_millis, manual_clock),
         manual_clock_(manual_clock) {}
 
   void SetWall(int64_t millis) { manual_clock_->SetWall(millis); }


### PR DESCRIPTION
Make the consolidated registry update its values based on the beginning
of the step instead of the end. And send values at the beginning of each
minute.

A simple test where we update a counter once per minute at each possible
second is added to ensure the basic expectation is met.