### PR TITLE
Properly count the number of validation errors

### DIFF
--- a/test/http_test.cc
+++ b/test/http_test.cc
@@ -96,7 +96,7 @@ rapidjson::Document MeasurementsToJson(
     int64_t now_millis,
     const interpreter::TagsValuePairs::const_iterator& first,
     const interpreter::TagsValuePairs::const_iterator& last, bool validate,
-    int64_t* metrics_added);
+    int64_t* metrics_added, int64_t* validation_errors);
 }  // namespace meter
 }  // namespace atlas
 
@@ -113,9 +113,9 @@ static rapidjson::Document get_json_doc() {
   tag_values.push_back(std::move(exp1));
   tag_values.push_back(std::move(exp2));
 
-  int64_t n;
+  int64_t n, e;
   return atlas::meter::MeasurementsToJson(1000, tag_values.begin(),
-                                          tag_values.end(), false, &n);
+                                          tag_values.end(), false, &n, &e);
 }
 
 TEST(HttpTest, PostBatches) {


### PR DESCRIPTION
Previously we were just using the number of measurements present versus the
number of measurements sent, but that also included measurements that
were valid and were not sent, for example, gauges with NaN values.